### PR TITLE
Rewrote codeplex startpage in markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,81 @@
+### C# Open Source Managed Operating System
+
+[We are currently migrating from codeplex](http://cosmos.codeplex.com/)
+
+Cosmos is an operating system "construction kit", built from the ground up around the IL2CPU compiler in C# and our home-brewed language called X#.
+
+It's current stage is only usable for academic work. Some day Cosmos will be ready for production work, but to reach that stage we need more developers. Specifically, we need a few more low level developers to help the few core developers who are currently overwhelmed with work.
+
+
+Download
+---------
+
+Cosmos is available in two forms:
+* **User Kit** - User Kit allows you to develop your own custom operating system in Visual Studio. 
+  If you are new to Cosmos, start here. Latest Release
+* **Dev Kit** - Dev Kit is the full Cosmos source with build tools. 
+  If you need to modify core Cosmos functions or modify built in drivers, boot, compiler, etc then you will need to use Dev Kit.
+  Building Dev Kit - Building from source is easy with our automated builder.
+
+
+Getting Started
+---------
+
+* [Cosmos Documentation](http://cosmos.codeplex.com/documentation)
+* Video: [Using VS Express Editions](https://www.youtube.com/watch?v=NNl8S2xOtdo)
+* [FAQ](http://cosmos.codeplex.com/wikipage?title=FAQ&referringTitle=Home)
+* [Low Hanging Fruit](http://cosmos.codeplex.com/workitem/list/advanced?Status=Active&page=0) - Looking for something easy to do and prove your worth in Cosmos? Here are a few easy tasks we have on our to do list that are also of importance to us.
+
+
+Joining Cosmos
+---------
+
+* [Yahoo Group](https://tech.groups.yahoo.com/group/Cosmos-Dev) - Email Discussion List. To prevent spambots from spamming our list we ask you introduce yourself to join. Please mention something specific to Cosmos. "Hey I want to join" won't get you in....
+* [Cosmos Chat Room](http://cosmos.codeplex.com/wikipage?title=Cosmos%20Chat%20Room&referringTitle=Home) - Live chat. When joining give some time for response. Asking a question and leaving a few minutes or seconds later will not give anyone any time to notice your presence.
+* [Facebook](http://www.facebook.com/pages/Cosmos-Operating-System/10235842745) - Like us to see frequent updates of what is going on with Cosmos.
+* [YouTube Channel](https://www.youtube.com/channel/UCsSKtqjfpSR0B3Ov4cBIarQ/) - Follow use to see useful videos.
+* [Resources](http://cosmos.codeplex.com/wikipage?title=Resources&referringTitle=Home) - More Cosmos related links.
+
+
+Articles and Resources
+---------
+
+* [Develop Your Own Operating System in C# or VB.NET](http://www.codeproject.com/KB/cs/CosmosMS5.aspx)
+* [Quick View Under the Hood](http://www.codeproject.com/KB/cs/CosmosUnderHood.aspx)
+* [Intro to Plugs](http://www.codeproject.com/KB/cs/CosmosPlugs.aspx)
+* [X86 Assembly Debugger Preview](http://www.codeproject.com/KB/cs/CosmosAsmDebuggerPreview.aspx)
+* [Making a Remote PC Slave for Debugging or Fun](http://www.codeproject.com/Articles/413942/Making-a-Remote-PC-Slave-for-Debugging-or-Fun)
+* [Cosmos Tutorials](http://www.thedevforum.com/forum-28.html)
+* [Cosmos Projects](http://cosmos.codeplex.com/wikipage?title=Cosmos%20Projects&referringTitle=Home)
+
+
+Publicity
+---------
+
+[Mary Jo Foley - Cosmos: An open-source .Net-based microkernel OS is born](http://www.zdnet.com/blog/microsoft/cosmos-an-open-source-net-based-microkernel-os-is-born/1162)
+[Scott Hanselman - Tiny Managed Operating System Edition](http://www.hanselman.com/blog/TheWeeklySourceCode15TinyManagedOperatingSystemEdition.aspx)
+
+
+Videos
+---------
+
+We encourage you to add your own Cosmos videos to YouTube. Please add the tags Cosmos and C# when uploading.
+
+**Official Videos** - Videos made by the Cosmos Team.
+
+* [Building your first Operating System in less than 60 seconds](http://www.youtube.com/watch?v=k5UPuPCY-5U)
+* [Cosmos Debugging](http://www.youtube.com/watch?v=oInLSZia4pQ)
+* [Cosmos PXE network boot with VMware](http://www.youtube.com/watch?v=kXwlg-NN8NI)
+* [Debugging on real hardware](http://www.youtube.com/watch?v=d_1Bup3TR_M)
+* [User Cosmos videos on YouTube (Cosmos, C#)](http://www.youtube.com/results?search_query=cosmos+c%23)
+
+**User Videos** - Selected videos made by Cosmos Users. Please note that we have not verified each of these videos.
+
+* [Cosmos Tutorial C# Lesson 1 - Part 1 - int0x10.com](https://www.youtube.com/watch?v=oKW3BrclAUY)
+* [Cosmos Tutorial C# Lesson 1 - Part 2 - int0x10.com](https://www.youtube.com/watch?v=V_Bxq0aGs_A)
+* [Cosmos Tutorial C# Lesson 2 - int0x10.com](https://www.youtube.com/watch?v=5Wzp1bGr8o0)
+
+
+![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=Cosmos&DownloadId=775267)
+
+![](http://download-codeplex.sec.s-msft.com/Download?ProjectName=Cosmos&DownloadId=775266)


### PR DESCRIPTION
Most links still points back to codeplex, next step is probably to port the documentation to the wikis
