### PR TITLE
Don't report output from NAsm as error in case of warnings

### DIFF
--- a/source/Cosmos.Build.MSBuild/BaseToolTask.cs
+++ b/source/Cosmos.Build.MSBuild/BaseToolTask.cs
@@ -94,8 +94,8 @@ namespace Cosmos.Build.MSBuild
 			xProcessStartInfo.RedirectStandardError = true;
       xProcessStartInfo.CreateNoWindow = true;
 
-      //Log.LogWarning("Running '{0}' with arguments: '{1}'", filename, arguments);
-      //Log.LogWarning("Working directory = '{0}'", workingDir);
+			Log.LogCommandLine(string.Format("Executing command line \"{0}\" {1}", filename, arguments));
+			Log.LogCommandLine(string.Format("Working directory = '{0}'", workingDir));
 
 			using (var xProcess = new Process())
 			{
@@ -130,32 +130,23 @@ namespace Cosmos.Build.MSBuild
 					  Log.LogError("Error occurred while invoking {0}.", name);
 					}
 				}
+
+        LogInfo logContent;
         foreach (var xError in mErrors)
         {
-          Log.LogError(xError);
+          if (ExtendLineError(xProcess.ExitCode, xError, out logContent))
+          {
+            Logs(logContent);
+          }
         }
+
         foreach (var xOutput in mOutput)
         {
-          Log.LogMessage(xOutput);
+					if (ExtendLineOutput(xProcess.ExitCode, xOutput, out logContent))
+          {
+            Logs(logContent);
+          }
         }
-
-        //while (!xProcess.StandardOutput.EndOfStream)
-        //{
-        //  var xLine = xProcess.StandardOutput.ReadLine();
-        //  if (xLine != null)
-        //  {
-        //    Log.LogMessage(xLine);
-        //  }
-        //}
-
-        //while (!xProcess.StandardError.EndOfStream)
-        //{
-        //  var xLine = xProcess.StandardError.ReadLine();
-        //  if (xLine != null)
-        //  {
-        //    Log.LogError(xLine);
-        //  }
-        //}
 
 				return xProcess.ExitCode == 0;
 			}
@@ -174,7 +165,7 @@ namespace Cosmos.Build.MSBuild
 	    return true;
 	  }
 
-	  public virtual bool ExtendLineOutput(int exitCode, ref string errorMessage, out LogInfo log)
+	  public virtual bool ExtendLineOutput(int exitCode, string errorMessage, out LogInfo log)
 	  {
 	    log = new LogInfo();
 	    log.logType = WriteType.Info;

--- a/source/Cosmos.Build.MSBuild/IL2CPU.cs
+++ b/source/Cosmos.Build.MSBuild/IL2CPU.cs
@@ -164,5 +164,13 @@ namespace Cosmos.Build.MSBuild {
         Log.LogMessage(MessageImportance.High, "IL2CPU task took {0}", xSW.Elapsed);
       }
     }
+
+		public override bool ExtendLineError(int exitCode, string errorMessage, out LogInfo log)
+		{
+			log = new LogInfo();
+			log.logType = WriteType.Error;
+			log.message = errorMessage;
+			return true;
+		}
   }
 }


### PR DESCRIPTION
IL2CPU task modified to keep current behaviour
Added diagnosting reporting of the command line executed. This command line is visible only if you run MSBuild with Diagnostic level of verbosity
Related to #50 