### PR TITLE
Added stobj stack push/pop information to OpType and some other smaller changes.

### DIFF
--- a/source/Cosmos.HAL/Cosmos.HAL.csproj
+++ b/source/Cosmos.HAL/Cosmos.HAL.csproj
@@ -116,6 +116,7 @@
     <Compile Include="PCIDeviceBridge.cs" />
     <Compile Include="PCIDeviceCardbus.cs" />
     <Compile Include="PCIDeviceNormal.cs" />
+    <Compile Include="PCSpeaker.cs" />
     <Compile Include="PIT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RTC.cs" />

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpType.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpType.cs
@@ -41,9 +41,11 @@ namespace Cosmos.IL2CPU.ILOpCodes {
         case Code.Constrained:
           return 0;
         case Code.Unbox_Any:
-             return 1;
+          return 1;
         case Code.Unbox:
-             return 1;
+          return 1;
+        case Code.Stobj:
+          return 2;
         default:
           throw new NotImplementedException("OpCode '" + OpCode + "' not implemented! Encountered in method " + aMethod.ToString());
       }
@@ -75,6 +77,8 @@ namespace Cosmos.IL2CPU.ILOpCodes {
           return 1;
         case Code.Unbox:
           return 1;
+        case Code.Stobj:
+          return 0;
         default:
           throw new NotImplementedException("OpCode '" + OpCode + "' not implemented!");
       }

--- a/source/Cosmos.IL2CPU/ILScanner.cs
+++ b/source/Cosmos.IL2CPU/ILScanner.cs
@@ -131,6 +131,12 @@ namespace Cosmos.IL2CPU
                 mItems.Add(aItem);
                 mItemsList.Add(aItem);
 
+                MethodBase methodBaseSource = aSrc as MethodBase;
+                if (methodBaseSource != null)
+                {
+                    aSrc = methodBaseSource.DeclaringType.ToString() + "::" + aSrc.ToString();
+                }
+
                 mQueue.Enqueue(new ScannerQueueItem() { Item = aItem, QueueReason = aSrcType, SourceItem = aSrc + Environment.NewLine + sourceItem });
             }
         }


### PR DESCRIPTION
(In relation to issue #72)

These changes add stobj's stack push/pop info to OpType. It looks like stobj was implemented, this information was just missing.

I ran into some [extra issues](https://github.com/CosmosOS/Cosmos/issues/72#issuecomment-94332305) with the sample code that caused this problem after I made this change, so it isn't as tested as I'd like.

There are two other less noteworthy changes in these commits:
* Added PCSpeaker.cs to the Cosmos.HAL project (it was accidentally removed recently, it seems.)
* I hacked in a change to make the call traces in IL2CPU's output slightly more useful when a plug is missing.

For the latter, it is a bit of a hack - so I understand if you don't want to merge it.
I just wasn't satisfied with MethodBase.ToString's output. It makes the output of a plug error look like this:

    Error occurred while invoking IL2CPU.
    Exception: System.Exception: Native code encountered, plug required. Please see http://cosmos.codeplex.com/wikipage?title=Plugs). System.Object  System.RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter(System.RuntimeType, System.RuntimeType).
     Called from :
    System.Collections.Generic.EqualityComparer`1[System.String]::System.Collections.Generic.EqualityComparer`1[System.String] CreateComparer()
    System.Collections.Generic.EqualityComparer`1[System.String]::System.Collections.Generic.EqualityComparer`1[System.String] get_Default()
    System.Collections.Generic.Dictionary`2[System.String,System.Int32]::Void .ctor(Int32, System.Collections.Generic.IEqualityComparer`1[System.String])
    System.Collections.Generic.Dictionary`2[System.String,System.Int32]::Void .ctor(Int32)
    CosmosKernel2.Kernel::Void Run()
    Cosmos.System.Kernel::Void Run()

Before, the types weren't listed so you didn't get as much context as to where CreateComparer actually existed, etc.