### PR TITLE
Fix String switch on Roslyn

### DIFF
--- a/source/Cosmos.IL2CPU/CompilerEngine.cs
+++ b/source/Cosmos.IL2CPU/CompilerEngine.cs
@@ -282,6 +282,11 @@ namespace Cosmos.IL2CPU
                 foreach (var xAsm in AppDomain.CurrentDomain.GetAssemblies())
                 {
                     // HACK: find another way to skip dynamic assemblies (which belong to dynamic methods)
+                    if (xAsm.IsDynamic)
+                    {
+                        continue;
+                    }
+
                     try
                     {
                         LogMessage(xAsm.Location);

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
@@ -631,6 +631,12 @@ namespace Cosmos.IL2CPU.ILOpCodes {
               aSituationChanged = true;
               return;
             }
+            if (StackPopTypes[0] == typeof(uint) && StackPopTypes[1] == typeof(char))
+            {
+              StackPushTypes[0] = typeof(uint);
+              aSituationChanged = true;
+              return;
+            }
             if (StackPopTypes[0] == typeof(byte) && StackPopTypes[1] == typeof(byte))
             {
               StackPushTypes[0] = typeof(byte);


### PR DESCRIPTION
String switch on Roslyn used operation Xor(UINT32, Char) which was currently not supported on IL2CPU.
By the way I fix dynamic assembly discovery which now shouldn't need try/catch so it don't mess up with debugging session when NotSupportetException is captured by debugger