### PR TITLE
Update the ToolsVersion value in the project files

### DIFF
--- a/Tests/Cosmos.Compiler.Tests.Interfaces/Cosmos.Compiler.Tests.Interfaces.KernelBoot.Cosmos
+++ b/Tests/Cosmos.Compiler.Tests.Interfaces/Cosmos.Compiler.Tests.Interfaces.KernelBoot.Cosmos
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Tests/Cosmos.Compiler.Tests.SimpleWriteLine.Kernel/Cosmos.Compiler.Tests.SimpleWriteLine.KernelBoot.Cosmos
+++ b/Tests/Cosmos.Compiler.Tests.SimpleWriteLine.Kernel/Cosmos.Compiler.Tests.SimpleWriteLine.KernelBoot.Cosmos
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Users/Emile/TestBed/TestBed/TestBedBoot.Cosmos
+++ b/Users/Emile/TestBed/TestBed/TestBedBoot.Cosmos
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Users/Sentinel/SentinelKernel/SentinelKernelBoot.Cosmos
+++ b/Users/Sentinel/SentinelKernel/SentinelKernelBoot.Cosmos
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
This allows to load projects using MSBuild when VS 2012 is not installed.
Since we don't support VS 2012, there no reason to have these files be in the old format.
These kernels lately would be used for unit testing, without that change this would not work.