### PR TITLE
Implemented some console methods and fixed a bug in the console, copying the behaviour of background color in windows console applications.

### DIFF
--- a/source/Cosmos.HAL/TextScreen.cs
+++ b/source/Cosmos.HAL/TextScreen.cs
@@ -8,82 +8,89 @@ using Cosmos.Debug.Kernel;
 namespace Cosmos.HAL {
   // Dont hold state here. This is a raw to hardware class. Virtual screens should be done
   // by memory moves
-  public class TextScreen : TextScreenBase {
-    protected byte   Color = 0x0F; // White
-    protected UInt16 mClearCellValue;
-    protected UInt32 mRow2Addr;
-    protected UInt32 mScrollSize;
-    protected Int32  mCursorSize = 25; // 25 % as C# Console class
-    protected bool   mCursorVisible = true;
-
-    protected Core.IOGroup.TextScreen IO = new Cosmos.Core.IOGroup.TextScreen();
-    protected readonly MemoryBlock08 mRAM;
-
-    public TextScreen() {
-
-      if (this is TextScreen)
-      {
-        TextScreenHelpers.Debug("this is TextScreen");
-      }
-      else
-      {
-        TextScreenHelpers.Debug("ERROR: This is not of type TextScreen!");
-      }
-      mRAM = IO.Memory.Bytes;
-      // Set the Console default colors: White foreground on Black background, the default value of mClearCellValue is set there too as it is linked with the Color
-      SetColors(ConsoleColor.White, ConsoleColor.Black);
-      mRow2Addr = (UInt32)(Cols * 2);
-      mScrollSize = (UInt32)(Cols * (Rows - 1) * 2);
-      SetCursorSize(mCursorSize);
-      SetCursorVisible(mCursorVisible);
-      TextScreenHelpers.Debug("End of TextScreen..ctor");
-    }
-
-    public override UInt16 Rows { get { return 25; } }
-    public override UInt16 Cols { get { return 80; } }
-
-    public override void Clear() {
-        TextScreenHelpers.Debug("Clearing screen with value ");
-        TextScreenHelpers.DebugNumber(mClearCellValue);
-        IO.Memory.Fill(mClearCellValue);
-    }
-
-    public override void ScrollUp()
+    public class TextScreen : TextScreenBase
     {
-      IO.Memory.MoveDown(0, mRow2Addr, mScrollSize);
-      //IO.Memory.Fill(mScrollSize, mRowSize32, mClearCellValue32);
-      IO.Memory.Fill(mScrollSize, Cols, mClearCellValue);
-    }
+        protected byte   Color = 0x0F; // White
+        protected UInt16 mBackgroundClearCellValue;
+        protected UInt16 mTextClearCellValue;
+        protected UInt32 mRow2Addr;
+        protected UInt32 mScrollSize;
+        protected Int32  mCursorSize = 25; // 25 % as C# Console class
+        protected bool   mCursorVisible = true;
 
-    public override char this[int aX, int aY]
-    {
-      get {
-        var xScreenOffset = (UInt32)((aX + aY * Cols) * 2);
-        return (char)mRAM[xScreenOffset];
-      }
-      set {
-        var xScreenOffset = (UInt32)((aX + aY * Cols) * 2);
-        mRAM[xScreenOffset] = (byte)value;
-        mRAM[xScreenOffset + 1] = Color;
-      }
-    }
+        protected Core.IOGroup.TextScreen IO = new Cosmos.Core.IOGroup.TextScreen();
+        protected readonly MemoryBlock08 mRAM;
 
-    public override void SetColors(ConsoleColor aForeground, ConsoleColor aBackground) {
-            Color = (byte)((byte)(aForeground) | ((byte)(aBackground) << 4));
-            // The Color | the NUL character this is used to Clear the Screen
-            mClearCellValue = (UInt16)(Color << 8 | 0x00);
+        public TextScreen()
+        {
+            if (this is TextScreen)
+            {
+                TextScreenHelpers.Debug("this is TextScreen");
+                }
+                else
+                {
+                TextScreenHelpers.Debug("ERROR: This is not of type TextScreen!");
+                }
+                mRAM = IO.Memory.Bytes;
+                // Set the Console default colors: White foreground on Black background, the default value of mClearCellValue is set there too as it is linked with the Color
+                SetColors(ConsoleColor.White, ConsoleColor.Black);
+            mBackgroundClearCellValue = mTextClearCellValue;
+                mRow2Addr = (UInt32)(Cols * 2);
+                mScrollSize = (UInt32)(Cols * (Rows - 1) * 2);
+                SetCursorSize(mCursorSize);
+                SetCursorVisible(mCursorVisible);
+                TextScreenHelpers.Debug("End of TextScreen..ctor");
         }
 
-    public override void SetCursorPos(int aX, int aY)
-    {
-      char xPos = (char)((aY * Cols) + aX);
-      // Cursor low byte to VGA index register
-      IO.Idx3.Byte = 0x0F;
-      IO.Data3.Byte = (byte)(xPos & 0xFF);
-      // Cursor high byte to VGA index register
-      IO.Idx3.Byte = 0x0E;
-      IO.Data3.Byte = (byte)(xPos >> 8);
-    }
+        public override UInt16 Rows { get { return 25; } }
+        public override UInt16 Cols { get { return 80; } }
+
+        public override void Clear() {
+            TextScreenHelpers.Debug("Clearing screen with value ");
+            TextScreenHelpers.DebugNumber(mTextClearCellValue);
+            IO.Memory.Fill(mTextClearCellValue);
+            mBackgroundClearCellValue = mTextClearCellValue;
+        }
+
+        public override void ScrollUp()
+        {
+            IO.Memory.MoveDown(0, mRow2Addr, mScrollSize);
+            //IO.Memory.Fill(mScrollSize, mRowSize32, mClearCellValue32);
+            IO.Memory.Fill(mScrollSize, Cols, mBackgroundClearCellValue);
+        }
+
+        public override char this[int aX, int aY]
+        {
+            get
+            {
+                var xScreenOffset = (UInt32)((aX + aY * Cols) * 2);
+                return (char)mRAM[xScreenOffset];
+            }
+            set
+            {
+                var xScreenOffset = (UInt32)((aX + aY * Cols) * 2);
+                mRAM[xScreenOffset] = (byte)value;
+                mRAM[xScreenOffset + 1] = Color;
+            }
+        }
+
+        public override void SetColors(ConsoleColor aForeground, ConsoleColor aBackground)
+        {
+            Color = (byte)((byte)(aForeground) | ((byte)(aBackground) << 4));
+            // The Color | the NUL character this is used to Clear the Screen
+            mTextClearCellValue = (UInt16)(Color << 8 | 0x00);
+        }
+
+        public override void SetCursorPos(int aX, int aY)
+        {
+            char xPos = (char)((aY * Cols) + aX);
+            // Cursor low byte to VGA index register
+            IO.Idx3.Byte = 0x0F;
+            IO.Data3.Byte = (byte)(xPos & 0xFF);
+            // Cursor high byte to VGA index register
+            IO.Idx3.Byte = 0x0E;
+            IO.Data3.Byte = (byte)(xPos >> 8);
+        }
         public override byte GetColor()
         {
             return Color;
@@ -99,7 +106,7 @@ namespace Cosmos.HAL {
             TextScreenHelpers.Debug("Changing cursor size to", value, "%");
             // We need to transform value from a percentage to a value from 15 to 0
             value = 16 - ((16 * value) / 100);
-            // This is the case in which value is in reality 1% and a for a truncation error we get 16 (invalid value) 
+            // This is the case in which value is in reality 1% and a for a truncation error we get 16 (invalid value)
             if (value >= 16)
                 value = 15;
             TextScreenHelpers.Debug("verticalSize is", value);
@@ -121,7 +128,7 @@ namespace Cosmos.HAL {
             byte cursorDisable;
 
             mCursorVisible = value;
-            
+
             // The VGA Cursor is disabled when the value is 1 and enabled when is 0 so we need to invert 'value', sadly the ConvertToByte() function is not working
             // so we need to do the if by hand...
             if (value == true)

--- a/source/Cosmos.System.Plugs/System/ConsoleImpl.cs
+++ b/source/Cosmos.System.Plugs/System/ConsoleImpl.cs
@@ -57,8 +57,7 @@ namespace Cosmos.System.Plugs.System
 
         public static bool get_CapsLock()
         {
-            WriteLine("Not implemented: get_CapsLock");
-            return false;
+            return Global.CapsLock;
         }
 
         public static int get_CursorLeft()
@@ -80,7 +79,15 @@ namespace Cosmos.System.Plugs.System
                 // for now:
                 return;
             }
-            xConsole.X = x;
+
+            if (x < get_WindowWidth())
+            {
+                xConsole.X = x;
+            }
+            else
+            {
+                WriteLine("x must be lower than the console width!");
+            }
         }
 
         public static int get_CursorSize()
@@ -124,13 +131,25 @@ namespace Cosmos.System.Plugs.System
                 // for now:
                 return;
             }
-            GetConsole().Y = y;
+
+            if (y < get_WindowHeight())
+            {
+                xConsole.Y = y;
+            }
+            else
+            {
+                WriteLine("y must be lower than the console height!");
+            }
         }
 
         public static bool get_CursorVisible()
         {
-            WriteLine("Not implemented: get_CursorVisible");
-            return false;
+            var xConsole = GetConsole();
+            if (xConsole == null)
+            {
+                return false;
+            }
+            return GetConsole().CursorVisible;
         }
 
         public static void set_CursorVisible(bool value)
@@ -199,8 +218,7 @@ namespace Cosmos.System.Plugs.System
 
         public static bool get_NumberLock()
         {
-            WriteLine("Not implemented: get_NumberLock");
-            return false;
+            return Global.NumLock;
         }
 
         //public static TextWriter get_Out() {
@@ -494,7 +512,8 @@ namespace Cosmos.System.Plugs.System
 
         public static void ResetColor()
         {
-            WriteLine("Not implemented: ResetColor");
+            set_BackgroundColor(ConsoleColor.Black);
+            set_ForegroundColor(ConsoleColor.White);
         }
 
         public static void SetBufferSize(int width, int height)
@@ -504,7 +523,8 @@ namespace Cosmos.System.Plugs.System
 
         public static void SetCursorPosition(int left, int top)
         {
-            WriteLine("Not implemented: SetCursorPosition");
+            set_CursorLeft(left);
+            set_CursorTop(top);
         }
 
         //public static void SetError(TextWriter newError) {


### PR DESCRIPTION
### This bug is fixed (after console height, background is filled with BackgroundColor and it shouldn't, only the text background should have that color):
(The methods that the screenshot shows as not implemented are implemented in this PR, but the bug is too, so I had to use Cosmos version from latest master to show the bug)

![console bug](https://cloud.githubusercontent.com/assets/10765201/16323911/ab31f826-39a6-11e6-8598-b21c44900108.png)