### PR TITLE
Fixed (short-short) op bug

### DIFF
--- a/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
@@ -705,6 +705,13 @@ namespace Cosmos.IL2CPU.ILOpCodes {
               aSituationChanged = true;
               return;
             }
+            //Changed
+            if (StackPopTypes[0] == typeof(short) && StackPopTypes[1] == typeof(short))
+            {
+              StackPushTypes[0] = typeof(short);
+              aSituationChanged = true;
+              return;
+            }
             if (StackPopTypes[0] == typeof(long) && StackPopTypes[1] == typeof(long))
             {
               StackPushTypes[0] = typeof(long);


### PR DESCRIPTION
Fixed short|short bug. Causing errors during compilation.
`1> Error: Exception: System.Exception: Error compiling method 'SystemVoidLiquiDOSHALACPIShutdown': System.Exception: Error interpreting stacktypes for IL_0036: Or ---> System.NotImplementedException: Or on types 'System.Int16' and 'System.Int16' not yet implemented!`