### PR TITLE
Added ASM instructions and basic DateTime-implementation

### DIFF
--- a/source/Cosmos.Assembler/Cosmos.Assembler.csproj
+++ b/source/Cosmos.Assembler/Cosmos.Assembler.csproj
@@ -138,10 +138,13 @@
     <Compile Include="InfraExtensions.cs" />
     <Compile Include="Instruction.cs" />
     <Compile Include="Label.cs" />
+    <Compile Include="x86\Lea.cs" />
     <Compile Include="LiteralAssemblerCode.cs" />
     <Compile Include="LabelName.cs" />
     <Compile Include="OpCodeAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="x86\Rdmsr.cs" />
+    <Compile Include="x86\Rdtsc.cs" />
     <Compile Include="StackContents.cs" />
     <Compile Include="TypeComparer.cs" />
     <Compile Include="x86\Add.cs" />

--- a/source/Cosmos.Assembler/x86/Lea.cs
+++ b/source/Cosmos.Assembler/x86/Lea.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cosmos.Assembler.x86
+{
+    /// <summary>
+    /// Represents the LEA-instruction (load effective address, 0x8d)
+    /// </summary>
+    [Cosmos.Assembler.OpCode("lea")]
+    public class Lea
+        : InstructionWithDestinationAndSourceAndSize
+    {
+        public Lea() : base("lea")
+        {
+        }
+    }
+}

--- a/source/Cosmos.Assembler/x86/Rdmsr.cs
+++ b/source/Cosmos.Assembler/x86/Rdmsr.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cosmos.Assembler.x86
+{
+    /// <summary>
+    /// Represents the RDMSR-instruction (read model specific register, 0x0f 0x32)
+    /// </summary>
+    [Cosmos.Assembler.OpCode("rdmsr")]
+    public class Rdmsr
+        : InstructionWithDestinationAndSourceAndSize
+    {
+        public Rdmsr() : base("rdmsr")
+        {
+        }
+    }
+}

--- a/source/Cosmos.Assembler/x86/Rdtsc.cs
+++ b/source/Cosmos.Assembler/x86/Rdtsc.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Cosmos.Assembler.x86
+{
+    /// <summary>
+    /// Represents the RDTSC-instruction (read timestamp counter, 0x0f 0x31)
+    /// </summary>
+    [Cosmos.Assembler.OpCode("rdtsc")]
+    public class Rdtsc
+        : InstructionWithDestinationAndSourceAndSize
+    {
+        public Rdtsc() : base("rdtsc")
+        {
+        }
+    }
+}

--- a/source/Cosmos.Core.Plugs/Cosmos.Core.Plugs.csproj
+++ b/source/Cosmos.Core.Plugs/Cosmos.Core.Plugs.csproj
@@ -105,6 +105,7 @@
     <Compile Include="System\Assemblers\GetMulticastInvokeAssembler.cs" />
     <Compile Include="System\Assemblers\InvokeImplAssembler.cs" />
     <Compile Include="System\Buffer.cs" />
+    <Compile Include="System\DateTimeImpl.cs" />
     <Compile Include="System\DelegateImpl.cs" />
     <Compile Include="System\IO\PathHelperImpl.cs" />
     <Compile Include="System\MulticastDelegateImpl.cs" />

--- a/source/Cosmos.Core.Plugs/System/DateTimeImpl.cs
+++ b/source/Cosmos.Core.Plugs/System/DateTimeImpl.cs
@@ -1,0 +1,66 @@
+﻿using System;
+
+using Cosmos.IL2CPU.Plugs;
+
+namespace Cosmos.Core.Plugs.System
+{
+    [Plug(Target = typeof(DateTime))]
+    public class DateTimeImpl
+    {
+
+        public DateTime get_Now()
+        {
+            int[] raw = GetRawDate();
+            
+            return new DateTime(
+                100 * BCDtoBIN(raw[10]) + BCDtoBIN(raw[9]), //YEAR
+                BCDtoBIN(raw[8]), //MONTH
+                BCDtoBIN(raw[7]), //DAY
+                BCDtoBIN(raw[4]), //HOUR
+                BCDtoBIN(raw[2]), //MINUTE
+                BCDtoBIN(raw[0]) //SECOND
+                );
+        }
+
+        public DateTime get_UtcNow()
+        {
+            // TODO: get timezone
+            return get_Now();
+        }
+
+        private static int[] GetRawDate()
+        {
+            IOPort p70 = new IOPort(0x70);
+            IOPort p71 = new IOPort(0x71);
+            int[] raw = new int[0x0b];
+
+            p70.Byte = 0x0b;
+            p71.Byte = 0x02; //24h format + BCD encoding
+
+            do
+                p70.Byte = 0x0a;
+            while ((p71.Byte & 0x80) == 0);
+
+            for (byte i = 0; i < 0x0a; i++)
+            {
+                p70.Byte = i;
+
+                raw[i] = p71.Word;
+            }
+
+            p70.Byte = 0x32;
+
+            raw[0x0a] = p71.Word;
+
+            return raw;
+        }
+
+        /// <summary>
+        /// Converts BCD-encoded numbers to `normal` (binary-encoded) numbers
+        /// </summary>
+        private static int BCDtoBIN(int bcd)
+        {
+            return ((bcd & 0xf0) >> 1) + ((bcd & 0xf0) >> 3) + (bcd & 0xf);
+        }
+    }
+}


### PR DESCRIPTION
Added the x86-instructions 'LEA', 'RDTSC' and 'RDMSR'.
Added a simplistic plug for 'system::datetime', which now contains the
method for fetching the current date/time