### PR TITLE
Fixed Template for Visual Basic kernel

### DIFF
--- a/source/Cosmos.VS.Package/Templates/Projects/CosmosKernel (VB)/Kernel.vb
+++ b/source/Cosmos.VS.Package/Templates/Projects/CosmosKernel (VB)/Kernel.vb
@@ -4,19 +4,20 @@ Imports System.Text
 
 Namespace $safeprojectname$
 
-	Public Class Kernel
-		Inherits Cosmos.System.Kernel
+    Public Class Kernel
+        Inherits Cosmos.System.Kernel
 
-		Protected Overrides Sub BeforeRun()
-			Console.WriteLine("Cosmos booted successfully. Type a line of text to get it echoed back.")
-		End Sub
+        Protected Overrides Sub BeforeRun()
+            Console.WriteLine("Cosmos booted successfully. Type a line of text to get it echoed back.")
+        End Sub
 
-		Protected Overrides Sub Run()
-			Console.Write("Input: ")
-			Console.ReadLine()
-			Console.Write("Text typed: ")
-		End Sub
+        Protected Overrides Sub Run()
+            Console.Write("Input: ")
+            Dim input = Console.ReadLine()
+            Console.Write("Text typed: ")
+            Console.WriteLine(input)
+        End Sub
 
-	End Class
+    End Class
 
 End Namespace

--- a/source/Cosmos.VS.Package/Templates/Projects/CosmosKernel (VB)/VBProjKernel.vbproj
+++ b/source/Cosmos.VS.Package/Templates/Projects/CosmosKernel (VB)/VBProjKernel.vbproj
@@ -21,7 +21,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG,TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/source/Cosmos.VS.Package/Templates/Projects/CosmosProject (VB)/Kernel.vb
+++ b/source/Cosmos.VS.Package/Templates/Projects/CosmosProject (VB)/Kernel.vb
@@ -4,19 +4,20 @@ Imports System.Text
 
 Namespace $safeprojectname$
 
-	Public Class Kernel
-		Inherits Cosmos.System.Kernel
+    Public Class Kernel
+        Inherits Cosmos.System.Kernel
 
-		Protected Overrides Sub BeforeRun()
-			Console.WriteLine("Cosmos booted successfully. Type a line of text to get it echoed back.")
-		End Sub
+        Protected Overrides Sub BeforeRun()
+            Console.WriteLine("Cosmos booted successfully. Type a line of text to get it echoed back.")
+        End Sub
 
-		Protected Overrides Sub Run()
-			Console.Write("Input: ")
-			Console.ReadLine()
-			Console.Write("Text typed: ")
-		End Sub
+        Protected Overrides Sub Run()
+            Console.Write("Input: ")
+            Dim input = Console.ReadLine()
+            Console.Write("Text typed: ")
+            Console.WriteLine(input)
+        End Sub
 
-	End Class
+    End Class
 
 End Namespace

--- a/source/Cosmos.VS.Package/Templates/Projects/CosmosProject (VB)/VBProjKernel.vbproj
+++ b/source/Cosmos.VS.Package/Templates/Projects/CosmosProject (VB)/VBProjKernel.vbproj
@@ -21,7 +21,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG,TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
- Visual Basict projects do not accept ';' as separator between the constant definitions they accept instead ','
- The example kernel was wrong as nothing was really echoed back!