### PR TITLE
Update OpNone.cs for Math.Round()

### DIFF
--- a/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
@@ -141,8 +141,9 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Ldelem_U1:
         case Code.Ldelem_U2:
         case Code.Ldelem_U4:
-          return 2;
         case Code.Ldelem_R4:
+        case Code.Ldelem_R8:
+          return 2;
         case Code.Ldnull:
           return 0;
         case Code.Dup:
@@ -274,6 +275,7 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Ldelem_U1:
         case Code.Ldelem_U2:
         case Code.Ldelem_U4:
+        case Code.Ldelem_R4:
         case Code.Ldelem_R8:
             return 1;
         case Code.Ldnull:

--- a/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
+++ b/source/Cosmos.IL2CPU/ILOpCodes/OpNone.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 
@@ -142,6 +142,7 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Ldelem_U2:
         case Code.Ldelem_U4:
           return 2;
+        case Code.Ldelem_R4:
         case Code.Ldnull:
           return 0;
         case Code.Dup:
@@ -273,7 +274,8 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Ldelem_U1:
         case Code.Ldelem_U2:
         case Code.Ldelem_U4:
-          return 1;
+        case Code.Ldelem_R8:
+            return 1;
         case Code.Ldnull:
           return 1;
         case Code.Dup:
@@ -467,10 +469,15 @@ namespace Cosmos.IL2CPU.ILOpCodes
         case Code.Ldelem_U4:
           StackPushTypes[0] = typeof(uint);
           return;
+        case Code.Ldelem_R4:
+            StackPushTypes[0] = typeof(float);
+            return;
+        case Code.Ldelem_R8:
+            StackPushTypes[0] = typeof(double);
+            return;
         case Code.Ldnull:
           StackPushTypes[0] = typeof(NullRef);
           return;
-
         case Code.Ldind_I:
           StackPushTypes[0] = typeof(IntPtr);
           return;


### PR DESCRIPTION
OS says Math.Round() is not implemented without the changes. It should work now!