### PR TITLE
Fixed the project templates for csproj, vbproj, and fsproj

### DIFF
--- a/source/Cosmos.VS.ProjectSystem/ProjectTemplates/CosmosKernel (VB)/VBProjKernel.vbproj
+++ b/source/Cosmos.VS.ProjectSystem/ProjectTemplates/CosmosKernel (VB)/VBProjKernel.vbproj
@@ -10,8 +10,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cosmos.Debug.Kernel" Version="1.0.*" />
-    <PackageReference Include="Cosmos.System" Version="1.0.*" />
+    <PackageReference Include="Cosmos.Debug.Kernel" Version="1.0.2-*" />
+    <PackageReference Include="Cosmos.System" Version="1.0.2-*" />
   </ItemGroup>
 
 </Project>

--- a/source/Cosmos.VS.ProjectSystem/ProjectTemplates/CosmosProject (CSharp)/CSharpProject.csproj
+++ b/source/Cosmos.VS.ProjectSystem/ProjectTemplates/CosmosProject (CSharp)/CSharpProject.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cosmos.Debug.Kernel" Version="1.0.*" />
-    <PackageReference Include="Cosmos.System" Version="1.0.*" />
+    <PackageReference Include="Cosmos.Debug.Kernel" Version="1.0.2-*" />
+    <PackageReference Include="Cosmos.System" Version="1.0.2-*" />
   </ItemGroup>
 
 </Project>

--- a/source/Cosmos.VS.ProjectSystem/ProjectTemplates/CosmosProject (FSharp)/FSharpProject.fsproj
+++ b/source/Cosmos.VS.ProjectSystem/ProjectTemplates/CosmosProject (FSharp)/FSharpProject.fsproj
@@ -10,8 +10,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cosmos.Debug.Kernel" Version="1.0.*" />
-    <PackageReference Include="Cosmos.System" Version="1.0.*" />
+    <PackageReference Include="Cosmos.Debug.Kernel" Version="1.0.2-*" />
+    <PackageReference Include="Cosmos.System" Version="1.0.2-*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I've fixed the references for the project templates, the CSharp project template is verified working, not too sure if the Visual Basic project template had other issues but the F Sharp project may have other issues too like beforehand. At least the C# project template is fixed now :)