### PR TITLE
Fixing WriteAllLines issue

### DIFF
--- a/Tests/Cosmos.Kernel.Tests.Fat/Kernel.cs
+++ b/Tests/Cosmos.Kernel.Tests.Fat/Kernel.cs
@@ -617,20 +617,18 @@ namespace Cosmos.Kernel.Tests.Fat
                 mDebugger.Send("END TEST");
                 mDebugger.Send("");
             }
-
-            // Generic methods on arrays don't work, see https://github.com/CosmosOS/Cosmos/issues/583
-            //
-            //string[] contents = { "One", "Two", "Three" };
-            //File.WriteAllLines(@"0:\test3.txt", contents);
-            //mDebugger.Send("Text written");
-            //mDebugger.Send("Now reading with ReadAllLines()");
-            //string[] readLines = File.ReadAllLines(@"0:\test3.txt");
-            //mDebugger.Send("Contents retrieved after writing");
-            //for (int i = 0; i < readLines.Length; i++)
-            //{
-            //    mDebugger.Send(readLines[i]);
-            //}
-            //Assert.IsTrue(StringArrayAreEquals(contents, readLines), "Contents of test3.txt was written incorrectly!");
+            
+            string[] contents = { "One", "Two", "Three" };
+            File.WriteAllLines(@"0:\test3.txt", contents);
+            mDebugger.Send("Text written");
+            mDebugger.Send("Now reading with ReadAllLines()");
+            string[] readLines = File.ReadAllLines(@"0:\test3.txt");
+            mDebugger.Send("Contents retrieved after writing");
+            for (int i = 0; i < readLines.Length; i++)
+            {
+                mDebugger.Send(readLines[i]);
+            }
+            Assert.IsTrue(StringArrayAreEquals(contents, readLines), "Contents of test3.txt was written incorrectly!");
 #if false
                 // TODO maybe the more correct test is to implement ReadAllLines and then check that two arrays are equals
                         var xContents = File.ReadAllText(@"0:\test3.txt");

--- a/source/Cosmos.System2_Plugs/System/IO/FileImpl.cs
+++ b/source/Cosmos.System2_Plugs/System/IO/FileImpl.cs
@@ -139,6 +139,8 @@ namespace Cosmos.System_Plugs.System.IO
         public static void WriteAllLines(string aFile, string[] contents)
         {
             string text = String.Join(Environment.NewLine, contents);
+            Global.mFileSystemDebugger.SendInternal("Writing contents");
+            Global.mFileSystemDebugger.SendInternal(text);
             WriteAllText(aFile, text);
         }
 

--- a/source/Cosmos.System2_Plugs/System/IO/FileImpl.cs
+++ b/source/Cosmos.System2_Plugs/System/IO/FileImpl.cs
@@ -120,18 +120,25 @@ namespace Cosmos.System_Plugs.System.IO
             return result;
         }
 
-        public static void WriteAllLines(string aFile, IEnumerable<string> contents)
+      /* public static void WriteAllLines(string aFile, IEnumerable<string> contents)
+       * {
+       *    string text = null;
+       *
+       *    foreach (var line in contents)
+       *    {
+       *        text = string.Concat(text, line, Environment.NewLine);
+       *    }
+       *
+       *    Global.mFileSystemDebugger.SendInternal("Writing contents");
+       *    Global.mFileSystemDebugger.SendInternal(text);
+       *
+       *    WriteAllText(aFile, text);
+       * }
+       */
+        
+        public static void WriteAllLines(string aFile, string[] contents)
         {
-            string text = null;
-
-            foreach (var line in contents)
-            {
-                text = string.Concat(text, line, Environment.NewLine);
-            }
-
-            Global.mFileSystemDebugger.SendInternal("Writing contents");
-            Global.mFileSystemDebugger.SendInternal(text);
-
+            string text = String.Join(Environment.NewLine, contents);
             WriteAllText(aFile, text);
         }
 

--- a/source/Cosmos.System2_Plugs/System/IO/FileImpl.cs
+++ b/source/Cosmos.System2_Plugs/System/IO/FileImpl.cs
@@ -119,28 +119,14 @@ namespace Cosmos.System_Plugs.System.IO
 
             return result;
         }
-
-      /* public static void WriteAllLines(string aFile, IEnumerable<string> contents)
-       * {
-       *    string text = null;
-       *
-       *    foreach (var line in contents)
-       *    {
-       *        text = string.Concat(text, line, Environment.NewLine);
-       *    }
-       *
-       *    Global.mFileSystemDebugger.SendInternal("Writing contents");
-       *    Global.mFileSystemDebugger.SendInternal(text);
-       *
-       *    WriteAllText(aFile, text);
-       * }
-       */
         
         public static void WriteAllLines(string aFile, string[] contents)
         {
             string text = String.Join(Environment.NewLine, contents);
+            
             Global.mFileSystemDebugger.SendInternal("Writing contents");
             Global.mFileSystemDebugger.SendInternal(text);
+            
             WriteAllText(aFile, text);
         }
 


### PR DESCRIPTION
Since IL2CPU doesn't support arrays as `IEnumerable<T>`
I changed WriteAllLines code
and convert string[] into a string ends with '\r\n' based on windows for creating New Line