### PR TITLE
check in batch before build for.net framework 4.7.1

### DIFF
--- a/install-VS2017.bat
+++ b/install-VS2017.bat
@@ -1,6 +1,22 @@
 @echo off
 cls
 
+echo Check for installed .NET Framework 4.7.1
+
+FOR /F "tokens=2*" %%A IN ('REG.EXE QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" /V "Release" 2^>NUL ^| FIND "REG_DWORD"') DO SET Ver=%%B
+IF "%Ver%"=="" (
+  echo .NET Framework 4.7.1 or 4.5 or above 4.5 is not installed. Please download from https://www.microsoft.com/net/download/visual-studio-sdks
+  pause
+  goto:eof
+)
+SET "NET471_CREATORS=0x709fc"
+
+if NOT "%NET471_CREATORS%"=="%Ver%" (
+  echo .NET Framework 4.7.1 is required.
+  pause
+  goto:eof
+)
+
 set NuGet=Build\Tools\nuget.exe
 set VSWhere=Build\Tools\vswhere.exe
 


### PR DESCRIPTION
When someone new press the install.bat the builder runs but with error. It is needed to install explicit the new .net Framework.
This Version number to check is from Windows 10 creators, but on MSDN is written that the verison on older Version is different. please check that. reference: https://docs.microsoft.com/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#net_b

Furthermore it would be good to check if IL2CPU and Xsharp Projects also exists.