### PR TITLE
move wait for VS into inno setup

### DIFF
--- a/Setup/Cosmos.iss
+++ b/Setup/Cosmos.iss
@@ -153,6 +153,79 @@ Filename: "{app}\Build\Tools\nuget.exe"; Parameters: "sources Remove -Name ""Cos
 Filename: "{app}\Build\Tools\VSIXBootstrapper.exe"; Parameters: "/q /u:Cosmos.VS.ProjectSystem"; StatusMsg: "Removing Visual Studio Extension: Cosmos Project System"
 
 [Code]
+function IsAppRunning(const FileName: string): Boolean;
+var
+  FWMIService: Variant;
+  FSWbemLocator: Variant;
+  FWbemObjectSet: Variant;
+begin
+  Result := false;
+  FSWbemLocator := CreateOleObject('WBEMScripting.SWBEMLocator');
+  FWMIService := FSWbemLocator.ConnectServer('', 'root\CIMV2', '', '');
+  FWbemObjectSet := FWMIService.ExecQuery(Format('SELECT Name FROM Win32_Process Where Name="%s"',[FileName]));
+  Result := (FWbemObjectSet.Count > 0);
+  FWbemObjectSet := Unassigned;
+  FWMIService := Unassigned;
+  FSWbemLocator := Unassigned;
+end;
+
+function IsAppRunningWithResponse(const FileName: string): Boolean;
+var
+  Retry: Integer;
+begin
+  Result := IsAppRunning(FileName);
+  if Result then
+    MsgBox(FileName  + ' is running. Please close the application before running the installer.', mbError, MB_OK);
+end;
+
+function InitializeSetup: boolean;
+var
+  Retry: Integer;
+begin
+for Retry := 0 to 2 do
+  begin
+    Result := not IsAppRunningWithResponse('devenv.exe');
+    if not Result then
+    begin
+      continue;
+    end;
+    Result := not IsAppRunningWithResponse('VSIXInstaller.exe');
+    if not Result then
+    begin
+      continue;
+    end;
+    Result := not IsAppRunningWithResponse('ServiceHub.IdentityHost.exe');
+    if not Result then
+    begin
+      continue;
+    end;
+    Result := not IsAppRunningWithResponse('ServiceHub.VSDetouredHost.exe');
+    if not Result then
+    begin
+      continue;
+    end;
+    Result := not IsAppRunningWithResponse('ServiceHub.Host.Node.x86.exe');
+    if not Result then
+    begin
+      continue;
+    end;
+    Result := not IsAppRunningWithResponse('ServiceHub.SettingsHost.exe');
+    if not Result then
+    begin
+      continue;
+    end;
+    Result := not IsAppRunningWithResponse('ServiceHub.Host.CLR.x86.exe');
+    if not Result then
+    begin
+      continue;
+    end
+    else
+    begin
+      break;
+    end;
+  end;
+end;
+
 function ExecWithResult(const Filename, Params, WorkingDir: String; const ShowCmd: Integer;
   const Wait: TExecWait; var ResultCode: Integer; var ResultString: AnsiString): Boolean;
 var

--- a/source/Cosmos.Build.Builder/CosmosTask.cs
+++ b/source/Cosmos.Build.Builder/CosmosTask.cs
@@ -120,22 +120,38 @@ namespace Cosmos.Build.Builder {
       }
     }
 
-    protected void CheckIfVSRunning() {
-      int xSeconds = 500;
-
-      if (Debugger.IsAttached) {
-        Log.WriteLine("Check if Visual Studio is running is ignored by debugging of Builder.");
-      } else {
-        Log.WriteLine("Check if Visual Studio is running.");
-        if (IsRunning("devenv")) {
-          Log.WriteLine("--Visual Studio is running.");
-          Log.WriteLine("--Waiting " + xSeconds + " seconds to see if Visual Studio exits.");
-          // VS doesnt exit right away and user can try devkit again after VS window has closed but is still running.
-          // So we wait a few seconds first.
-          if (WaitForExit("devenv", xSeconds * 1000)) {
-            throw new Exception("Visual Studio is running. Please close it or kill it in task manager.");
-          }
-        }
+    protected void CheckIfVSandCoRunning() {
+      bool xRunningFound = false;
+      if (IsRunning("devenv")) {
+        xRunningFound = true;
+        Log.WriteLine("--Visual Studio is running.");
+      }
+      if (IsRunning("VSIXInstaller")) {
+        xRunningFound = true;
+        Log.WriteLine("--VSIXInstaller is running.");
+      }
+      if (IsRunning("ServiceHub.IdentityHost")) {
+        xRunningFound = true;
+        Log.WriteLine("--ServiceHub.IdentityHost is running.");
+      }
+      if (IsRunning("ServiceHub.VSDetouredHost")) {
+        xRunningFound = true;
+        Log.WriteLine("--ServiceHub.VSDetouredHost is running.");
+      }
+      if (IsRunning("ServiceHub.Host.Node.x86")) {
+        xRunningFound = true;
+        Log.WriteLine("--ServiceHub.Host.Node.x86 is running.");
+      }
+      if (IsRunning("ServiceHub.SettingsHost")) {
+        xRunningFound = true;
+        Log.WriteLine("--ServiceHub.SettingsHost is running.");
+      }
+      if (IsRunning("ServiceHub.Host.CLR.x86")) {
+        xRunningFound = true;
+        Log.WriteLine("--ServiceHub.Host.CLR.x86 is running.");
+      }
+      if (xRunningFound) {
+        Log.WriteLine("--Running blockers found. Setup will warning you and wait for it.");
       }
     }
 
@@ -148,7 +164,7 @@ namespace Cosmos.Build.Builder {
       Section("Check Prerequisites");
 
       CheckIfUserKitRunning();
-      CheckIfVSRunning();
+      CheckIfVSandCoRunning();
       CheckIfBuilderRunning();
 
       CheckForNetCore();

--- a/source/Cosmos.Build.Installer/Paths.cs
+++ b/source/Cosmos.Build.Installer/Paths.cs
@@ -85,7 +85,7 @@ namespace Cosmos.Build.Installer
 
         if (xCurrentInstance == null)
         {
-          throw new Exception("The found Visual Studio instances are not the expected Visual Studio 2017!");
+          throw new Exception("There is more than one Visual Studio instance installed, but neither one of them matches the specified path: " + VSPath);
         }
       }
 

--- a/source/Cosmos.Build.Installer/Paths.cs
+++ b/source/Cosmos.Build.Installer/Paths.cs
@@ -85,7 +85,7 @@ namespace Cosmos.Build.Installer
 
         if (xCurrentInstance == null)
         {
-          throw new Exception("The Visual Studio instance is invalid!");
+          throw new Exception("The found Visual Studio instances are not the expected Visual Studio 2017!");
         }
       }
 


### PR DESCRIPTION
The builder should not wait until VS is closed, this is work of the Setup itself. Furthermore we check now for Addition applications which are checked by VSIXInstaller.exe before Installation.