### PR TITLE
Fix Blinking Text on (VGA that can blink)

### DIFF
--- a/source/Cosmos.HAL2/TextScreen.cs
+++ b/source/Cosmos.HAL2/TextScreen.cs
@@ -78,7 +78,12 @@ namespace Cosmos.HAL
 
         public override void SetColors(ConsoleColor aForeground, ConsoleColor aBackground)
         {
-            Color = (byte)((byte)(aForeground) | ((byte)(aBackground) << 4));
+            //Color = (byte)((byte)(aForeground) | ((byte)(aBackground) << 4));
+            // TODO: Use Real Mode to clear in Mode Control Register Index 10
+            //       the third bit to disable blinking and use the seventh bit
+            //       as the bright bit on background color for brighter colors :)
+            Color = (byte)(((byte)(aForeground) | ((byte)(aBackground) << 4)) & 0x7F);
+            
             // The Color | the NUL character this is used to Clear the Screen
             mTextClearCellValue = (UInt16)(Color << 8 | 0x00);
         }


### PR DESCRIPTION
## Fixes:
 - Fixes #559
## Changes:
 - Clear the **seventh bit**(0) in `TextScreen.cs` at method `SetColors(ConsoleColor, ConsoleColor)`.

### Is it the true fix?
**No**, the real fix is to switch to real mode and clear in Mode Control Register (Index 10) the third bit to disable blinking and enable the background bright bit for dark gray and other brighten colors.

 ---
(0) = "Seventh bit is defaultly the blinking bit by the bios, if set to 1: the written text after the `SetColors` method will blink forever, if set to 0: none of the above will happen.