### PR TITLE
Little fix on PCI VendorID.

### DIFF
--- a/source/Cosmos.HAL2/Drivers/PCI/Network/AMDPCNetII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Network/AMDPCNetII.cs
@@ -135,7 +135,7 @@ namespace Cosmos.HAL.Drivers.PCI.Network
         public static void FindAll()
         {
           Console.WriteLine("Scanning for AMD PCNetII cards...");
-          // PCIDevice device = Cosmos.HAL.PCI.GetDevice(0x1022, 0x2000);
+          //  PCIDevice device = Cosmos.HAL.PCI.GetDevice(VendorID.AMD, DeviceID.PCNETII);
           //  if (device != null)
           // {
           //      AMDPCNetII nic = new AMDPCNetII((PCIDeviceNormal) device);

--- a/source/Cosmos.HAL2/PCI.cs
+++ b/source/Cosmos.HAL2/PCI.cs
@@ -61,13 +61,14 @@ namespace Cosmos.HAL
     public enum VendorID
     {
         Intel = 0x8086,
-        AMD = 0x0438,
+        AMD = 0x1022,
         VMWare = 0x15AD
     }
     
     public enum DeviceID
     {
-        SVGAIIAdapter = 0x0405
+        SVGAIIAdapter = 0x0405,
+        PCNETII = 0x2000
     }
 
     public class PCI


### PR DESCRIPTION
AMD Vendor ID is 0x1022 not 0x0438.