### PR TITLE
Add checks for IL2CPU and XSharp repositories and solution files

### DIFF
--- a/source/Cosmos.Build.Builder/CosmosTask.cs
+++ b/source/Cosmos.Build.Builder/CosmosTask.cs
@@ -20,6 +20,8 @@ namespace Cosmos.Build.Builder {
     private string mSourcePath; // Cosmos source rood
     private string mInnoPath;
     private string mInnoFile;
+    private string mIL2CPUPath;
+    private string mXSPath;
 
     private BuildState mBuildState;
     private int mReleaseNo;
@@ -33,6 +35,8 @@ namespace Cosmos.Build.Builder {
 
       mReleaseNo = aReleaseNo;
       mInnoFile = Path.Combine(mCosmosPath, @"Setup\Cosmos.iss");
+      mXSPath = Path.GetFullPath(Path.Combine(mCosmosPath, @"..\XSharp"));
+      mIL2CPUPath = Path.GetFullPath(Path.Combine(mCosmosPath, @"..\IL2CPU"));
     }
 
     /// <summary>
@@ -171,8 +175,32 @@ namespace Cosmos.Build.Builder {
       CheckForNetCore();
       CheckForVisualStudioExtensionTools();
       CheckForInno();
+      CheckForRepos();
 
       return mBuildState != BuildState.PrerequisiteMissing;
+    }
+
+    private void CheckForRepos()
+    {
+      Log.WriteLine("Checking for existing IL2CPU and XSharp repositories...");
+      if (!Directory.Exists(mIL2CPUPath))
+      {
+        if (!File.Exists(Path.Combine(mIL2CPUPath, @"IL2CPU.sln")))
+        {
+          mExceptionList.Add("Missing IL2CPU Repository! Make sure to clone IL2CPU in the parent directory of Cosmos! Download IL2CPU and extract to " + mIL2CPUPath + ".");
+          mBuildState = BuildState.PrerequisiteMissing;
+          return;
+        }
+      }
+      else if (!Directory.Exists(mXSPath))
+      {
+        if (!File.Exists(Path.Combine(mXSPath, @"XSharp.sln")))
+        {
+          mExceptionList.Add("Missing XSharp Repository! Make sure to clone XSharp in the parent directory of Cosmos! Download XSharp and extract to " + mXSPath + ".");
+          mBuildState = BuildState.PrerequisiteMissing;
+          return;
+        }
+      }
     }
 
     private void CheckForInno() {


### PR DESCRIPTION
As to why GitHub can't display the changes in a simple way, I don't know but I'll explain em anyway
```
    private string mIL2CPUPath;
    private string mXSPath;
```
IL2CPU and XSharp paths were added to CosmosTask class, and 
```
mXSPath = Path.GetFullPath(Path.Combine(mCosmosPath, @"..\XSharp"));
mIL2CPUPath = Path.GetFullPath(Path.Combine(mCosmosPath, @"..\IL2CPU"));
```
were added to the CosmosTask constructor, with a new method that does the following:
```
    private void CheckForRepos()
    {
      Log.WriteLine("Checking for existing IL2CPU and XSharp repositories...");
      if (!Directory.Exists(mIL2CPUPath))
      {
        if (!File.Exists(Path.Combine(mIL2CPUPath, @"IL2CPU.sln")))
        {
          mExceptionList.Add("Missing IL2CPU Repository! Make sure to clone IL2CPU in the parent directory of Cosmos! Download IL2CPU and extract to " + mIL2CPUPath + ".");
          mBuildState = BuildState.PrerequisiteMissing;
          return;
        }
      }
      else if (!Directory.Exists(mXSPath))
      {
        if (!File.Exists(Path.Combine(mXSPath, @"XSharp.sln")))
        {
          mExceptionList.Add("Missing XSharp Repository! Make sure to clone XSharp in the parent directory of Cosmos! Download XSharp and extract to " + mXSPath + ".");
          mBuildState = BuildState.PrerequisiteMissing;
          return;
        }
      }
    }
```
Which is called from the PrereqsOK() bool method.

