### PR TITLE
Fixed String Replace

### DIFF
--- a/source/Cosmos.Core_Plugs/System/StringImpl.cs
+++ b/source/Cosmos.Core_Plugs/System/StringImpl.cs
@@ -728,11 +728,19 @@ namespace Cosmos.Core_Plugs.System
 
         public static string Replace(string aThis, string oldValue, string newValue)
         {
-            while (aThis.IndexOf(oldValue) != -1)
+            int skipOffset = 0;
+
+            while (aThis.IndexOf(oldValue, skipOffset) != -1)
             {
-                int xIndex = aThis.IndexOf(oldValue);
+                int xIndex = aThis.IndexOf(oldValue, skipOffset);
                 aThis = aThis.Remove(xIndex, oldValue.Length);
                 aThis = aThis.Insert(xIndex, newValue);
+
+                skipOffset = (xIndex + newValue.Length + 1);
+                if (skipOffset > aThis.Length)
+                {
+                    break;
+                }
             }
             return aThis;
         }


### PR DESCRIPTION
Fixed issue in #943 

When `newValue` contains `oldValue` the function would attempt to replace it indefinably.
It should now skip over characters it already modified.