### PR TITLE
Fix DrawImage

### DIFF
--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -401,7 +401,7 @@ namespace Cosmos.System.Graphics
         //We are using a short term solution for bitmap
         public void DrawImage(Image image, int x, int y)
         {
-            for (int imageX = 0; imageX < image.Width; inageX++)
+            for (int imageX = 0; imageX < image.Width; imageX++)
             {
                 for (int imageY = 0; imageY < image.Height; imageY++)
                 {

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -405,7 +405,7 @@ namespace Cosmos.System.Graphics
             {
                 for (int imageY = 0; imageY < image.Height; imageY++)
                 {
-                    DrawPoint(new Pen(Color.FromArgb(image.rawData[imageX * image.Width + _y])), x + imageX, y + imageX);
+                    DrawPoint(new Pen(Color.FromArgb(image.rawData[imageX * image.Width + _y])), x + imageX, y + imageY);
                 }
             }
         }

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -405,7 +405,7 @@ namespace Cosmos.System.Graphics
             {
                 for (int imageY = 0; imageY < image.Height; imageY++)
                 {
-                    DrawPoint(new Pen(Color.FromArgb(image.rawData[imageX * image.Width + _y])), x + imageX, y + imageY);
+                    DrawPoint(new Pen(Color.FromArgb(image.rawData[imageX * image.Width + imageY])), x + imageX, y + imageY);
                 }
             }
         }

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -401,9 +401,9 @@ namespace Cosmos.System.Graphics
         //We are using a short term solution for bitmap
         public virtual void DrawImage(Image image, int x, int y)
         {
-            for (int imageX = 0; imageX < image.Width; imageX++)
+             for (int imageY = 0; imageY < image.Height; imageY++)           
             {
-                for (int imageY = 0; imageY < image.Height; imageY++)
+                for (int imageX = 0; imageX < image.Width; imageX++)
                 {
                     DrawPoint(new Pen(Color.FromArgb(image.rawData[imageX * image.Width + imageY])), x + imageX, y + imageY);
                 }

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -399,7 +399,7 @@ namespace Cosmos.System.Graphics
         //Image and Font will be available in .NET Core 2.1
         // dot net core does not have Image
         //We are using a short term solution for bitmap
-        public void DrawImage(Image image, int x, int y)
+        public virtual void DrawImage(Image image, int x, int y)
         {
             for (int imageX = 0; imageX < image.Width; imageX++)
             {

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -401,11 +401,11 @@ namespace Cosmos.System.Graphics
         //We are using a short term solution for bitmap
         public void DrawImage(Image image, int x, int y)
         {
-            for (int _x = 0; _x < image.Width; _x++)
+            for (int imageX = 0; imageX < image.Width; inageX++)
             {
-                for (int _y = 0; _y < image.Height; _y++)
+                for (int imageY = 0; imageY < image.Height; imageY++)
                 {
-                    DrawPoint(new Pen(Color.FromArgb(image.rawData[_x + _y * image.Width])), x + _x, y + _y);
+                    DrawPoint(new Pen(Color.FromArgb(image.rawData[imageX * image.Width + _y])), x + imageX, y + imageX);
                 }
             }
         }


### PR DESCRIPTION
I fixed the errored `DrawImage` method that before accessed the wrong image data colors (`imageY * image.Width` was wrong, it would skip a lot of data and scramble everything)