### PR TITLE
Alternative method of GetAmountOfRAM().

### DIFF
--- a/Users/KaanGaming/GetAbsoluteRAM.cs
+++ b/Users/KaanGaming/GetAbsoluteRAM.cs
@@ -1,0 +1,18 @@
+// Note that it will fix Cosmos.Core.CPU's method, GetAmountOfRAM(). Because, it can't access the RAM completely.
+
+using Cosmos.Core;
+using System;
+
+namespace Users.KaanGaming
+{
+    public class CPU
+    {
+        /// <summary>Gets amount of RAM. If you don't want to use it, you can use <see cref="Cosmos.Core.CPU.GetAmountOfRAM()"/>.</summary>
+        /// <returns>Returns an unregistered integer value.</returns>
+        public static uint GetAmountOfRAM()
+        {
+            uint AbsoluteSize = Cosmos.Core.CPU.GetAmountOfRAM() + 2;
+            return AbsoluteSize;
+        }
+    }
+}


### PR DESCRIPTION
I added this to Users/KaanGaming folder because the CPU class in the source of Cosmos.Core looks very compiled. So, I didn't want to start a pull request about of CPU class. Instead, created a new folder & created a new file inside it.