### PR TITLE
Added condition on StrToByteArray in order to prevent CPU exception

### DIFF
--- a/source/Cosmos.Common/ByteToString.cs
+++ b/source/Cosmos.Common/ByteToString.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Common
     {
         public static byte[] StrToByteArray(string str)
         {
-            if (str.Length == 0 || !StringHelper.IsNumeric(str))
+            if (str.Length == 0 || !StringHelper.IsNumeric(str) || !StringHelper.IsLengthDivisible(str, 3))
                 throw new Exception("Invalid string value in StrToByteArray");
 
             byte val;

--- a/source/Cosmos.Common/ByteToString.cs
+++ b/source/Cosmos.Common/ByteToString.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Common
     {
         public static byte[] StrToByteArray(string str)
         {
-            if (str.Length == 0)
+            if (str.Length == 0 || !StringHelper.IsNumeric(str))
                 throw new Exception("Invalid string value in StrToByteArray");
 
             byte val;

--- a/source/Cosmos.Common/ByteToString.cs
+++ b/source/Cosmos.Common/ByteToString.cs
@@ -8,7 +8,7 @@ namespace Cosmos.Common
     {
         public static byte[] StrToByteArray(string str)
         {
-            if (str.Length == 0 || !StringHelper.IsNumeric(str) || !StringHelper.IsLengthDivisible(str, 3))
+            if (str.Length == 0 || !StringHelper.IsNumeric(str) || str.Length % 3 != 0)
                 throw new Exception("Invalid string value in StrToByteArray");
 
             byte val;

--- a/source/Cosmos.Common/StringHelper.cs
+++ b/source/Cosmos.Common/StringHelper.cs
@@ -410,6 +410,16 @@ namespace Cosmos.Common {
             }
             return (int)StringComparisonResultEnum.Equal;
         }
+
+        /// <summary>
+        /// Check if string is numeric.
+        /// </summary>
+        /// <param name="aString">A string to check if numeric.</param>
+        /// <returns>Returns TRUE if string is numeric.</returns>
+        public static bool IsNumeric(string aString) {
+            int i = 0;
+            return int.TryParse(aString, out i);
+        }
     }
 }
 

--- a/source/Cosmos.Common/StringHelper.cs
+++ b/source/Cosmos.Common/StringHelper.cs
@@ -427,6 +427,18 @@ namespace Cosmos.Common {
             }
             return true;
         }
+
+        /// <summary>
+        /// Check if string lenght is divisible by a given number.
+        /// </summary>
+        /// <param name="aString">A string to check if it's length is divisible.</param>
+        /// <param name="aNum">A denominator</param>
+        /// <returns>Returns TRUE if string length divisible by the given number.</returns>
+        public static bool IsLengthDivisible(string aString, int aNum) {
+            if (aNum != 0 && aString.Length % aNum == 0) {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/source/Cosmos.Common/StringHelper.cs
+++ b/source/Cosmos.Common/StringHelper.cs
@@ -419,9 +419,6 @@ namespace Cosmos.Common {
         public static bool IsNumeric(string aString) {
             for (int i = 0; i < aString.Length; i++) {
                 if (!char.IsDigit(aString[i])) {
-                    if (i == 0 && aString[i].Equals('-')) {
-                        continue;
-                    }
                     return false;
                 }
             }

--- a/source/Cosmos.Common/StringHelper.cs
+++ b/source/Cosmos.Common/StringHelper.cs
@@ -417,8 +417,16 @@ namespace Cosmos.Common {
         /// <param name="aString">A string to check if numeric.</param>
         /// <returns>Returns TRUE if string is numeric.</returns>
         public static bool IsNumeric(string aString) {
-            int i = 0;
-            return int.TryParse(aString, out i);
+            for (int i = 0; i < aString.Length; i++) {
+                if (!char.IsDigit(aString[i])) {
+                    if (i == 0 && aString[i].Equals('-')) {
+                        continue;
+                    }
+                    return false;
+                }
+            }
+            return true;
+        }
         }
     }
 }

--- a/source/Cosmos.Common/StringHelper.cs
+++ b/source/Cosmos.Common/StringHelper.cs
@@ -424,19 +424,6 @@ namespace Cosmos.Common {
             }
             return true;
         }
-
-        /// <summary>
-        /// Check if string lenght is divisible by a given number.
-        /// </summary>
-        /// <param name="aString">A string to check if it's length is divisible.</param>
-        /// <param name="aNum">A denominator</param>
-        /// <returns>Returns TRUE if string length divisible by the given number.</returns>
-        public static bool IsLengthDivisible(string aString, int aNum) {
-            if (aNum != 0 && aString.Length % aNum == 0) {
-                return true;
-            }
-            return false;
-        }
     }
 }
 


### PR DESCRIPTION
Added new condition check on the str that passed to the StrToByteArray function.
This condition check if the passed string is in a numeric format.
Currently there is no check for this, and as byte.Parse is called on the non-numeric string it throws System.FormatException, which is currently seems to be unhandled, causing CPU exception.
This condition should prevent this behaviour.

This problem discussed on #1333 issue.