### PR TITLE
Update Global.cs

### DIFF
--- a/source/Cosmos.HAL2/Global.cs
+++ b/source/Cosmos.HAL2/Global.cs
@@ -38,7 +38,7 @@ namespace Cosmos.HAL
             //TODO: Since this is FCL, its "common". Otherwise it should be
             // system level and not accessible from Core. Need to think about this
             // for the future.
-
+            Console.Clear();
             Console.WriteLine("Finding PCI Devices");
             mDebugger.Send("PCI Devices");
             PCI.Setup();


### PR DESCRIPTION
When using PXE boot or USB Boot the syslinux text remains on screen making the kernel output hard to read.