### PR TITLE
Made API documentation visable while using the userkit

### DIFF
--- a/source/Cosmos.Core/Cosmos.Core.csproj
+++ b/source/Cosmos.Core/Cosmos.Core.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Cosmos.Core_Asm/Cosmos.Core_Asm.csproj
+++ b/source/Cosmos.Core_Asm/Cosmos.Core_Asm.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Cosmos.Core_Plugs/Cosmos.Core_Plugs.csproj
+++ b/source/Cosmos.Core_Plugs/Cosmos.Core_Plugs.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Cosmos.Debug.Kernel.Plugs.Asm/Cosmos.Debug.Kernel.Plugs.Asm.csproj
+++ b/source/Cosmos.Debug.Kernel.Plugs.Asm/Cosmos.Debug.Kernel.Plugs.Asm.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Cosmos.Debug.Kernel/Cosmos.Debug.Kernel.csproj
+++ b/source/Cosmos.Debug.Kernel/Cosmos.Debug.Kernel.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Cosmos.HAL2/Cosmos.HAL2.csproj
+++ b/source/Cosmos.HAL2/Cosmos.HAL2.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Cosmos.HAL</RootNamespace>
     </PropertyGroup>
 

--- a/source/Cosmos.System2/Cosmos.System2.csproj
+++ b/source/Cosmos.System2/Cosmos.System2.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Cosmos.System</RootNamespace>
     </PropertyGroup>
 

--- a/source/Cosmos.System2_Plugs/Cosmos.System2_Plugs.csproj
+++ b/source/Cosmos.System2_Plugs/Cosmos.System2_Plugs.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Cosmos.System_Plugs</RootNamespace>
     </PropertyGroup>
 

--- a/source/Kernel-TapRoot/Demo/TRKernel.csproj
+++ b/source/Kernel-TapRoot/Demo/TRKernel.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/source/Kernel-X86/10-CPU/Cosmos.CPU.x86/Cosmos.CPU.x86.csproj
+++ b/source/Kernel-X86/10-CPU/Cosmos.CPU.x86/Cosmos.CPU.x86.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Kernel-X86/10-CPU/Cosmos.CPU_Asm/Cosmos.CPU_Asm.csproj
+++ b/source/Kernel-X86/10-CPU/Cosmos.CPU_Asm/Cosmos.CPU_Asm.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Kernel-X86/10-CPU/Cosmos.CPU_Plugs/Cosmos.CPU_Plugs.csproj
+++ b/source/Kernel-X86/10-CPU/Cosmos.CPU_Plugs/Cosmos.CPU_Plugs.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/source/Kernel-X86/20-Platform/Cosmos.Platform.PC/Cosmos.Platform.PC.csproj
+++ b/source/Kernel-X86/20-Platform/Cosmos.Platform.PC/Cosmos.Platform.PC.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Kernel-X86/30-HAL/Cosmos.HAL/Cosmos.HAL.csproj
+++ b/source/Kernel-X86/30-HAL/Cosmos.HAL/Cosmos.HAL.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Kernel-X86/40-System/Cosmos.System/Cosmos.System.csproj
+++ b/source/Kernel-X86/40-System/Cosmos.System/Cosmos.System.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Kernel-X86/50-Application/GuessKernelGen3.csproj
+++ b/source/Kernel-X86/50-Application/GuessKernelGen3.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/source/Kernel-X86/91-Plugs/Cosmos.Plugs.TapRoot/Cosmos.Plugs.TapRoot.csproj
+++ b/source/Kernel-X86/91-Plugs/Cosmos.Plugs.TapRoot/Cosmos.Plugs.TapRoot.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <RootNamespace>Cosmos.Plugs</RootNamespace>
     </PropertyGroup>
 


### PR DESCRIPTION
Currently any API documentation of any cosmos lib is unavailable for the user.
When using the userkit, you can not see any reference of any method of cosmos.
Added GenerateDocumentationFile property in all the libs, so xml documentation would be generated with the NuGet package.
There is a lot of benefits in letting the users to see it.
Notice: This might slow down the IDE for some low-end PCs