### PR TITLE
Enable Slaves on IDE

### DIFF
--- a/source/Cosmos.HAL2/BlockDevice/IDE.cs
+++ b/source/Cosmos.HAL2/BlockDevice/IDE.cs
@@ -14,12 +14,12 @@ namespace Cosmos.HAL.BlockDevice
             {
                 Console.WriteLine("ATA Primary Master");
                 Initialize(Ata.ControllerIdEnum.Primary, Ata.BusPositionEnum.Master);
-                //Console.WriteLine("ATA Primary Slave");
-                //Initialize(Ata.ControllerIdEnum.Primary, Ata.BusPositionEnum.Slave);
+                Console.WriteLine("ATA Primary Slave");
+                Initialize(Ata.ControllerIdEnum.Primary, Ata.BusPositionEnum.Slave);
                 Console.WriteLine("ATA Secondary Master");
                 Initialize(Ata.ControllerIdEnum.Secondary, Ata.BusPositionEnum.Master);
-                //Console.WriteLine("ATA Secondary Slave");
-                //Initialize(Ata.ControllerIdEnum.Secondary, Ata.BusPositionEnum.Slave);
+                Console.WriteLine("ATA Secondary Slave");
+                Initialize(Ata.ControllerIdEnum.Secondary, Ata.BusPositionEnum.Slave);
             }
         }
 


### PR DESCRIPTION
Enabling Slaves on the IDE causes no Issues it rather enables HDD detection on Computers that did not detect the hdd beforehand, ie. Laptops that assing the Optical Drive as Master and the HDD as Slave.