### PR TITLE
Update PS2Controller.cs

### DIFF
--- a/source/Cosmos.HAL2/PS2Controller.cs
+++ b/source/Cosmos.HAL2/PS2Controller.cs
@@ -238,7 +238,6 @@ namespace Cosmos.HAL
                     mDebugger.SendInternal("Second Byte: " + xSecondByte);
                     Console.WriteLine("(PS/2 Controller) Device detection failed.");
                     Console.WriteLine("This is usually Fine for USB to PS / 2 Emulation");
-                    Console.WriteLine("If your device does not work please open a Issue on Github");
                     Console.WriteLine("Press any key to Resume (Good Luck)");
                     Console.ReadLine();
                 }

--- a/source/Cosmos.HAL2/PS2Controller.cs
+++ b/source/Cosmos.HAL2/PS2Controller.cs
@@ -198,11 +198,8 @@ namespace Cosmos.HAL
                      */
                     else if (xFirstByte == 0xAB && ReadDataWithTimeout(ref xSecondByte))
                     {
-                        // TODO: replace xTest with (xSecondByte == 0x41 || xSecondByte == 0xC1)
-                        //       when the stack corruption detection works better for complex conditions
-                        var xTest = (xSecondByte == 0x41 || xSecondByte == 0xC1);
 
-                        if (xTest && aPort == 1)
+                        if ((xSecondByte == 0x41 || xSecondByte == 0xC1) && aPort == 1)
                         {
                             var xDevice = new PS2Keyboard(aPort);
                             xDevice.Initialize();
@@ -239,7 +236,11 @@ namespace Cosmos.HAL
                     mDebugger.SendInternal("(PS/2 Controller) Device detection failed:");
                     mDebugger.SendInternal("First Byte: " + xFirstByte);
                     mDebugger.SendInternal("Second Byte: " + xSecondByte);
-                    throw new Exception("(PS/2 Controller) PS/2 device not supported");
+                    Console.WriteLine("(PS/2 Controller) Device detection failed.");
+                    Console.WriteLine("This is usually Fine for USB to PS / 2 Emulation");
+                    Console.WriteLine("If your device does not work please open a Issue on Github");
+                    Console.WriteLine("Press any key to Resume (Good Luck)");
+                    Console.ReadLine();
                 }
             }
             else


### PR DESCRIPTION
Dont throw an exception on PS/2 Dectection Failure, USB Connected Devices tend to go through a USB to PS/2 Emulator. This means for example mice are PS/2 Devices in this case but dont operate on IRQ12 as the USB Bus Generates a IRQ. so this atleast makes most keyboards work. also the inline can go into the if statement now.