### PR TITLE
Update CPU.cs

### DIFF
--- a/source/Cosmos.Core/CPU.cs
+++ b/source/Cosmos.Core/CPU.cs
@@ -294,7 +294,7 @@ namespace Cosmos.Core
 
                 if (!(rs == ""))
                 {
-                    return rs;
+                    return rs.Trim();
                 }
                 else
                 {


### PR DESCRIPTION
add .Trim() to the returned string because otherwise it is shifted to the right using Console.WriteLine