### PR TITLE
Add GetDevice function with bus, slot, function informations

### DIFF
--- a/source/Cosmos.HAL2/PCI.cs
+++ b/source/Cosmos.HAL2/PCI.cs
@@ -164,6 +164,27 @@ namespace Cosmos.HAL
             return null;
         }
 
+        /// <summary>
+        /// Get device.
+        /// </summary>
+        /// <param name="bus">Bus ID.</param>
+        /// <param name="slot">Slot position ID.</param>
+        /// <param name="function">Function ID.</param>
+        /// <returns></returns>
+        public static PCIDevice GetDevice(uint bus, uint slot, uint function)
+        {
+            foreach (var xDevice in Devices)
+            {
+                if (xDevice.bus == bus &&
+                    xDevice.slot == slot &&
+                    xDevice.function == function)
+                {
+                    return xDevice;
+                }
+            }
+            return null;
+        }
+
         public static PCIDevice GetDeviceClass(ClassID Class, SubclassID SubClass)
         {
             foreach (var xDevice in Devices)


### PR DESCRIPTION
Useful to be able to get multiples PCI devices with the same Vendor ID & Device ID.