### PR TITLE
Implement non linear framebuffer detection for VBE multiboot

### DIFF
--- a/source/Cosmos.HAL2/Drivers/Video/VBEDriver.cs
+++ b/source/Cosmos.HAL2/Drivers/Video/VBEDriver.cs
@@ -81,8 +81,21 @@ namespace Cosmos.HAL.Drivers
             if (VBE.IsAvailable()) //VBE VESA Enabled Mulitboot Parsing
             {
                 Global.mDebugger.SendInternal($"Creating VBE VESA driver with Mode {xres}*{yres}@{bpp}");
-                IO.LinearFrameBuffer = new MemoryBlock(VBE.getLfbOffset(), (uint)xres * yres * (uint)(bpp / 8));
-                lastbuffer = new ManagedMemoryBlock((uint)xres * yres * (uint)(bpp / 8));
+
+                var ModeInfo = VBE.getModeInfo();
+
+                if ((ModeInfo.pitch / 4) == ModeInfo.width) //linear framebuffer detection
+                {
+                    IO.LinearFrameBuffer = new MemoryBlock(VBE.getLfbOffset(), (uint)xres * yres * (uint)(bpp / 8));
+                    lastbuffer = new ManagedMemoryBlock((uint)xres * yres * (uint)(bpp / 8));
+                }
+                else
+                {
+                    uint OffScreenSize = (ModeInfo.pitch / (uint)(bpp / 8)) - ModeInfo.width;
+
+                    IO.LinearFrameBuffer = new MemoryBlock(VBE.getLfbOffset(), (uint)(xres * yres * (uint)(bpp / 8)) + (OffScreenSize * yres * (uint)(bpp / 8)));
+                    lastbuffer = new ManagedMemoryBlock((uint)(xres * yres * (uint)(bpp / 8)) + (OffScreenSize * yres * (uint)(bpp / 8)));
+                }
             }
             else if (ISAModeAvailable()) //Bochs Graphics Adaptor ISA Mode
             {

--- a/source/Cosmos.HAL2/Drivers/Video/VBEDriver.cs
+++ b/source/Cosmos.HAL2/Drivers/Video/VBEDriver.cs
@@ -84,7 +84,7 @@ namespace Cosmos.HAL.Drivers
 
                 var ModeInfo = VBE.getModeInfo();
 
-                if ((ModeInfo.pitch / 4) == ModeInfo.width) //linear framebuffer detection
+                if ((ModeInfo.pitch / (bpp / 8)) == ModeInfo.width) //linear framebuffer detection
                 {
                     IO.LinearFrameBuffer = new MemoryBlock(VBE.getLfbOffset(), (uint)xres * yres * (uint)(bpp / 8));
                     lastbuffer = new ManagedMemoryBlock((uint)xres * yres * (uint)(bpp / 8));


### PR DESCRIPTION
Real hardware doesn't often use a linear framebuffer. It can causes graphics issues.