### PR TITLE
Update VMWareSVGAII.cs

### DIFF
--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -473,7 +473,10 @@ namespace Cosmos.HAL.Drivers.PCI.Video
         /// Capabilities.
         /// </summary>
         private uint capabilities;
-
+        /// <summary>
+        /// Fifo Cap Limit
+        /// </summary>
+        private uint FIFO_CAP;
         /// <summary>
         /// Create new instance of the <see cref="VMWareSVGAII"/> class.
         /// </summary>
@@ -494,6 +497,8 @@ namespace Cosmos.HAL.Drivers.PCI.Video
             Video_Memory = new MemoryBlock(ReadRegister(Register.FrameBufferStart), ReadRegister(Register.VRamSize));
             capabilities = ReadRegister(Register.Capabilities);
             InitializeFIFO();
+            //This calculates a approximate offset of the FIFO Cap limit used in WaitForFifo 
+            FIFO_CAP = (GetFIFO(FIFO.Max) - GetFIFO(FIFO.Min)) / 4;
         }
 
         /// <summary>
@@ -576,9 +581,8 @@ namespace Cosmos.HAL.Drivers.PCI.Video
         /// </summary>
         protected void WaitForFifo()
         {
-            //We dont correctly check if the FIFO is full, this calculates a approximate offset and resets NextCmd and Stop
+            //We dont correctly check if the FIFO is full, this resets NextCmd and Stop
             //After the reset we clear the FIFO memory which populates itself again.
-            uint FIFO_CAP = (GetFIFO(FIFO.Max) - GetFIFO(FIFO.Min)) / 4; 
             WriteRegister(Register.Sync, 1);
              if (GetFIFO(FIFO.Stop) > FIFO_CAP)
              {

--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -576,7 +576,17 @@ namespace Cosmos.HAL.Drivers.PCI.Video
         /// </summary>
         protected void WaitForFifo()
         {
+            //We dont correctly check if the FIFO is full, this calculates a approximate offset and resets NextCmd and Stop
+            //After the reset we clear the FIFO memory which populates itself again.
+            uint FIFO_CAP = (GetFIFO(FIFO.Max) - GetFIFO(FIFO.Min)) / 4; 
             WriteRegister(Register.Sync, 1);
+             if (GetFIFO(FIFO.Stop) > FIFO_CAP)
+             {
+              SetFIFO(FIFO.NextCmd, GetFIFO(FIFO.Min));
+              SetFIFO(FIFO.Stop, GetFIFO(FIFO.Min));
+              FIFO_Memory.Fill(0);
+              return;
+             }
             while (ReadRegister(Register.Busy) != 0) { }
         }
 

--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -586,8 +586,6 @@ namespace Cosmos.HAL.Drivers.PCI.Video
             WriteRegister(Register.Sync, 1);
              if (GetFIFO(FIFO.Stop) > FIFO_CAP)
              {
-              SetFIFO(FIFO.NextCmd, GetFIFO(FIFO.Min));
-              SetFIFO(FIFO.Stop, GetFIFO(FIFO.Min));
               FIFO_Memory.Fill(0);
               return;
              }


### PR DESCRIPTION
**Do not merge yet**
Reset FIFO.Stop and FIFO.NextCmd , this fixes 50% of a SVGA freeze and makes it more stable when a lot of stuff is drawn on screen, the remaining 50% seem to be in the memory allocation, also clearing the FIFO memory improves performance by 50% a 600FPS bare SVGA screen went up to the double .