### PR TITLE
Update VMWareSVGAII.cs

### DIFF
--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -517,6 +517,8 @@ namespace Cosmos.HAL.Drivers.PCI.Video
         /// <param name="depth">Depth.</param>
         public void SetMode(uint width, uint height, uint depth = 32)
         {
+            //Disable the Driver before writing new values and initiating it again to avoid a memory exception
+            Disable();
             // Depth is color depth in bytes.
             this.depth = (depth / 8);
             this.width = width;
@@ -753,6 +755,11 @@ namespace Cosmos.HAL.Drivers.PCI.Video
                 WriteToFifo(0xFFFFFF);
             WaitForFifo();
         }
+        //Allow to enable the Driver again after it has been disable (switch between text and graphics mode currently this is SVGA only)
+        public void Enable()
+        {
+            WriteRegister(Register.Enable, 1);
+        } 
         
         public void Disable()
         {

--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -756,11 +756,16 @@ namespace Cosmos.HAL.Drivers.PCI.Video
             WaitForFifo();
         }
         //Allow to enable the Driver again after it has been disabled (switch between text and graphics mode currently this is SVGA only)
+        /// <summary>
+        /// Enable the SVGA Driver , only needed after Disable() has been called
+        /// </summary>
         public void Enable()
         {
             WriteRegister(Register.Enable, 1);
         } 
-        
+        /// <summary>
+        /// Disable the SVGA Driver , return to text mode
+        /// </summary>
         public void Disable()
         {
             WriteRegister(Register.Enable, 0);

--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -526,7 +526,7 @@ namespace Cosmos.HAL.Drivers.PCI.Video
             WriteRegister(Register.Width, width);
             WriteRegister(Register.Height, height);
             WriteRegister(Register.BitsPerPixel, depth);
-            WriteRegister(Register.Enable, 1);
+            Enable();
             InitializeFIFO();
         }
 
@@ -755,7 +755,7 @@ namespace Cosmos.HAL.Drivers.PCI.Video
                 WriteToFifo(0xFFFFFF);
             WaitForFifo();
         }
-        //Allow to enable the Driver again after it has been disable (switch between text and graphics mode currently this is SVGA only)
+        //Allow to enable the Driver again after it has been disabled (switch between text and graphics mode currently this is SVGA only)
         public void Enable()
         {
             WriteRegister(Register.Enable, 1);


### PR DESCRIPTION
Fix SVGA to avoid a Index out of Bounds crash that happened due to a double memory write.
With this we disable the Driver before writing new values to the FIFO and initiating the memory again, before we initiated the memory regardless if it was already set or not and sent garbage to the FIFO causing it to crash. Also introduce the ability to switch between Graphics And Text mode.