### PR TITLE
Fix IRQs

### DIFF
--- a/source/Cosmos.Core/PIC.cs
+++ b/source/Cosmos.Core/PIC.cs
@@ -42,7 +42,7 @@ namespace Cosmos.Core
         /// </summary>
         public void EoiMaster()
         {
-            Master.Cmd.Byte = (byte) Cmd.EOI;
+            Master.Cmd.Byte = (byte)Cmd.EOI;
         }
 
         /// <summary>
@@ -59,19 +59,12 @@ namespace Cosmos.Core
         /// </summary>
         public PIC()
         {
-            // MTW: to disable PIT, send 0x01 to Master mask
-            // Right now we mask all IRQs. We enable them as we add
-            // support for them. The 0x08 on master MUST remain. IRQ7
-            // has a problem of "spurious requests" and is therefore unreliable.
-            // It used for LPT2 (and sometimes old 8 bit sound blasters). We likely
-            // won't need either of those for a very long time, so we just mask it
-            // completely. For more info:
-            // http://en.wikipedia.org/wiki/Intel_8259#Spurious_Interrupts
+            //Remap PIC.
+            //TODO: Make sure that the IRQ is not Spurious.
+            //Learn more here: http://en.wikipedia.org/wiki/Intel_8259#Spurious_Interrupts
 
-            //Init(Master, 0x20, 4, 0xFD | 0x08);
-            //Init(Slave, 0x28, 2, 0xFF);
             //for now enable keyboard, mouse(ps2)
-            Remap(0x20, 0xF8 | 0x08, 0x28, 0xEB);
+            Remap(0x20, 0x28);
         }
 
         /// <summary>
@@ -81,7 +74,7 @@ namespace Cosmos.Core
         /// <param name="masterMask">Master mask.</param>
         /// <param name="slaveStart">Slave start.</param>
         /// <param name="slaveMask">Slave mask.</param>
-        private void Remap(byte masterStart, byte masterMask, byte slaveStart, byte slaveMask)
+        private void Remap(byte masterStart, byte slaveStart)
         {
             #region consts
 
@@ -102,9 +95,6 @@ namespace Cosmos.Core
 #pragma warning restore
 
             #endregion
-
-            var xOldMasterMask = Master.Data.Byte;
-            var xOldSlaveMask = Slave.Data.Byte;
             Master.Cmd.Byte = ICW1_INIT + ICW1_ICW4;
             IOPort.Wait();
             Slave.Cmd.Byte = ICW1_INIT + ICW1_ICW4;
@@ -126,55 +116,10 @@ namespace Cosmos.Core
             Slave.Data.Byte = ICW4_8086;
             IOPort.Wait();
 
-            // set masks:
-            Master.Data.Byte = masterMask;
+            // set masks to none
+            Master.Data.Byte = 0;
             IOPort.Wait();
-            //Slave.Data.Byte = slaveMask;
-            //IOPort.Wait();
-        }
-
-        /// <summary>
-        /// Initialize PIC.
-        /// </summary>
-        /// <param name="aPIC">A PIC.</param>
-        /// <param name="aBase">A base data port.</param>
-        /// <param name="aIDunno">Slave relationship message.</param>
-        /// <param name="aMask">A mask.</param>
-        protected void Init(IOGroup.PIC aPIC, byte aBase, byte aIDunno, byte aMask)
-        {
-            // We need to remap the PIC interrupt lines to the CPU. The BIOS sets
-            // them in a way compatible for 16 bit mode, but in a way that causes problems
-            // for 32 bit mode.
-            // The only way to remap them however is to completely reinitialize the PICs.
-
-            byte xOldMask = aPIC.Data.Byte;
-
-            //#define ICW1_ICW4	0x01		/* ICW4 (not) needed */
-            //#define ICW1_SINGLE	0x02		/* Single (cascade) mode */
-            //#define ICW1_INTERVAL4	0x04		/* Call address interval 4 (8) */
-            //#define ICW1_LEVEL	0x08		/* Level triggered (edge) mode */
-            Master.Cmd.Byte = (byte) Cmd.Init | 0x01;
-            IOPort.Wait();
-
-            // ICW2
-            Master.Data.Byte = aBase;
-            IOPort.Wait();
-
-            // ICW3
-            // Somehow tells them about master/slave relationship
-            Master.Data.Byte = aIDunno;
-            IOPort.Wait();
-
-            //#define ICW4_AUTO	0x02		/C:\Data\Cosmos\source2\Kernel\System\Hardware\Core\Cosmos.Core\CPU.cs* Auto (normal) EOI */
-            //#define ICW4_BUF_SLAVE	0x08		/* Buffered mode/slave */
-            //#define ICW4_BUF_MASTER	0x0C		/* Buffered mode/master */
-            //#define ICW4_SFNM	0x10		/* Special fully nested (not) */
-            //0x01 8086/88 (MCS-80/85) mode
-            Master.Data.Byte = 0x01;
-            IOPort.Wait();
-
-            // Set mask
-            Master.Data.Byte = aMask;
+            Slave.Data.Byte = 0;
             IOPort.Wait();
         }
     }


### PR DESCRIPTION
This PR fixes a problem where IRQs don't get called because they are masked. Right now, Cosmos just masks all interrupts, expect for the keyboard and mouse, which could cause problems with drivers.