### PR TITLE
Fixes #1820

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,3 +58,8 @@ artifacts:
   - path: 'artifacts\Debug\nupkg\*.nupkg'
   - path: 'artifacts\Debug\VSIX\*.vsix'
   - path: 'TestResult.xml'
+
+
+skip_commits:
+  files:
+    - Docs/


### PR DESCRIPTION
Fixes #1820, excludes the Docs/ folder in commits to save AppVeyor rebuilding if just the docs change.
If there are changes in a commit including source code as well, it will build that commit as there is no rule matching - source/