### PR TITLE
Add VFSManager.Initialize(bool aShowInfo)

### DIFF
--- a/source/Cosmos.System2/FileSystem/CosmosVFS.cs
+++ b/source/Cosmos.System2/FileSystem/CosmosVFS.cs
@@ -36,7 +36,7 @@ namespace Cosmos.System.FileSystem
         /// <exception cref="System.Security.SecurityException">Thrown on fatal error.</exception>
         /// <exception cref="FileNotFoundException">Thrown on memory error.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown on fatal error.</exception>
-        public override void Initialize()
+        public override void Initialize(bool aShowInfo)
         {
             mPartitions = new List<Partition>();
             mFileSystems = new List<FileSystem>();
@@ -44,10 +44,10 @@ namespace Cosmos.System.FileSystem
 
             RegisterFileSystem(new FatFileSystemFactory());
 
-            InitializePartitions();
+            InitializePartitions(aShowInfo);
             if (mPartitions.Count > 0)
             {
-                InitializeFileSystems();
+                InitializeFileSystems(aShowInfo);
             }
         }
 
@@ -549,7 +549,7 @@ namespace Cosmos.System.FileSystem
         /// Initializes the partitions for all block devices.
         /// </summary>
         /// <exception cref="IOException">Thrown on I/O exception.</exception>
-        protected virtual void InitializePartitions()
+        protected virtual void InitializePartitions(bool aShowInfo)
         {
             for (int i = 0; i < BlockDevice.Devices.Count; i++)
             {
@@ -559,27 +559,30 @@ namespace Cosmos.System.FileSystem
                 }
             }
 
-            if (mPartitions.Count > 0)
+            if (aShowInfo)
             {
-                for (int i = 0; i < mPartitions.Count; i++)
+                if (mPartitions.Count > 0)
                 {
-                    Global.mFileSystemDebugger.SendInternal("Partition #: ");
-                    Global.mFileSystemDebugger.SendInternal(i + 1);
-                    global::System.Console.WriteLine("Partition #: " + (i + 1));
-                    Global.mFileSystemDebugger.SendInternal("Block Size:");
-                    Global.mFileSystemDebugger.SendInternal(mPartitions[i].BlockSize);
-                    global::System.Console.WriteLine("Block Size: " + mPartitions[i].BlockSize + " bytes");
-                    Global.mFileSystemDebugger.SendInternal("Block Count:");
-                    Global.mFileSystemDebugger.SendInternal(mPartitions[i].BlockCount);
-                    global::System.Console.WriteLine("Block Count: " + mPartitions[i].BlockCount);
-                    Global.mFileSystemDebugger.SendInternal("Size:");
-                    Global.mFileSystemDebugger.SendInternal(mPartitions[i].BlockCount * mPartitions[i].BlockSize / 1024 / 1024);
-                    global::System.Console.WriteLine("Size: " + mPartitions[i].BlockCount * mPartitions[i].BlockSize / 1024 / 1024 + " MB");
+                    for (int i = 0; i < mPartitions.Count; i++)
+                    {
+                        Global.mFileSystemDebugger.SendInternal("Partition #: ");
+                        Global.mFileSystemDebugger.SendInternal(i + 1);
+                        global::System.Console.WriteLine("Partition #: " + (i + 1));
+                        Global.mFileSystemDebugger.SendInternal("Block Size:");
+                        Global.mFileSystemDebugger.SendInternal(mPartitions[i].BlockSize);
+                        global::System.Console.WriteLine("Block Size: " + mPartitions[i].BlockSize + " bytes");
+                        Global.mFileSystemDebugger.SendInternal("Block Count:");
+                        Global.mFileSystemDebugger.SendInternal(mPartitions[i].BlockCount);
+                        global::System.Console.WriteLine("Block Count: " + mPartitions[i].BlockCount);
+                        Global.mFileSystemDebugger.SendInternal("Size:");
+                        Global.mFileSystemDebugger.SendInternal(mPartitions[i].BlockCount * mPartitions[i].BlockSize / 1024 / 1024);
+                        global::System.Console.WriteLine("Size: " + mPartitions[i].BlockCount * mPartitions[i].BlockSize / 1024 / 1024 + " MB");
+                    }
                 }
-            }
-            else
-            {
-                global::System.Console.WriteLine("No partitions found!");
+                else
+                {
+                    global::System.Console.WriteLine("No partitions found!");
+                }
             }
         }
 
@@ -596,7 +599,7 @@ namespace Cosmos.System.FileSystem
         /// <exception cref="System.Security.SecurityException">Thrown on fatal error.</exception>
         /// <exception cref="FileNotFoundException">Thrown on memory error.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown on fatal error.</exception>
-        protected virtual void InitializeFileSystems()
+        protected virtual void InitializeFileSystems(bool aShowInfo)
         {
             for (int i = 0; i < mPartitions.Count; i++)
             {
@@ -613,16 +616,19 @@ namespace Cosmos.System.FileSystem
                     }
                 }
 
-                if ((mFileSystems.Count > 0) && (mFileSystems[mFileSystems.Count - 1].RootPath == xRootPath))
+                if (aShowInfo)
                 {
-                    string xMessage = string.Concat("Initialized ", mFileSystems.Count, " filesystem(s)...");
-                    global::System.Console.WriteLine(xMessage);
-                    mFileSystems[i].DisplayFileSystemInfo();
-                }
-                else
-                {
-                    string xMessage = string.Concat("No filesystem found on partition #", i);
-                    global::System.Console.WriteLine(xMessage);
+                    if ((mFileSystems.Count > 0) && (mFileSystems[mFileSystems.Count - 1].RootPath == xRootPath))
+                    {
+                        string xMessage = string.Concat("Initialized ", mFileSystems.Count, " filesystem(s)...");
+                        global::System.Console.WriteLine(xMessage);
+                        mFileSystems[i].DisplayFileSystemInfo();
+                    }
+                    else
+                    {
+                        string xMessage = string.Concat("No filesystem found on partition #", i);
+                        global::System.Console.WriteLine(xMessage);
+                    }
                 }
             }
         }

--- a/source/Cosmos.System2/FileSystem/VFS/VFSBase.cs
+++ b/source/Cosmos.System2/FileSystem/VFS/VFSBase.cs
@@ -5,14 +5,14 @@ using System.IO;
 namespace Cosmos.System.FileSystem.VFS
 {
     /// <summary>
-    /// Virtual file system base abstract class. 
+    /// Virtual file system base abstract class.
     /// </summary>
     public abstract class VFSBase
     {
         /// <summary>
         /// Initializes the <see cref="VFSBase"/> system.
         /// </summary>
-        public abstract void Initialize();
+        public abstract void Initialize(bool aShowInfo);
 
         /// <summary>
         /// Register file system.

--- a/source/Cosmos.System2/FileSystem/VFS/VFSManager.cs
+++ b/source/Cosmos.System2/FileSystem/VFS/VFSManager.cs
@@ -29,7 +29,7 @@ namespace Cosmos.System.FileSystem.VFS
         /// <exception cref="System.Security.SecurityException">Thrown on fatal error.</exception>
         /// <exception cref="FileNotFoundException">Thrown on memory error.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown on fatal error.</exception>
-        public static void RegisterVFS(VFSBase aVFS, bool aAllowReinitialise = false)
+        public static void RegisterVFS(VFSBase aVFS, bool aShowInfo = true, bool aAllowReinitialise = false)
         {
             Global.mFileSystemDebugger.SendInternal("--- VFSManager.RegisterVFS ---");
             if (!aAllowReinitialise && mVFS != null)
@@ -37,7 +37,7 @@ namespace Cosmos.System.FileSystem.VFS
                 throw new Exception("Virtual File System Manager already initialized!");
             }
 
-            aVFS.Initialize();
+            aVFS.Initialize(aShowInfo);
             mVFS = aVFS;
         }
 

--- a/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
+++ b/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
@@ -25,7 +25,7 @@ namespace Cosmos.System.Graphics
         /// Debugger.
         /// </summary>
         internal Debugger mSVGAIIDebugger = new Debugger("System", "SVGAIIScreen");
-        
+
         private static readonly Mode _DefaultMode = new Mode(1024, 768, ColorDepth.ColorDepth32);
 
         /// <summary>
@@ -96,7 +96,8 @@ namespace Cosmos.System.Graphics
             {
                 return;
             }
-            else if (xColor.A < 255)
+
+            if (xColor.A < 255)
             {
                 xColor = AlphaBlend(xColor, GetPointColor(aX, aY), xColor.A);
             }
@@ -105,8 +106,8 @@ namespace Cosmos.System.Graphics
             _xSVGADriver.SetPixel((uint)aX, (uint)aY, (uint)xColor.ToArgb());
             mSVGAIIDebugger.SendInternal($"Done drawing point");
             /* No need to refresh all the screen to make the point appear on Screen! */
-            //xSVGAIIDriver.Update((uint)x, (uint)y, (uint)mode.Columns, (uint)mode.Rows);
-            _xSVGADriver.Update((uint)aX, (uint)aY, 1, 1);
+            //xSVGAIIDriver.Update((uint)x, (uint)y, (uint)mode.Width, (uint)mode.Height);
+            //_xSVGADriver.Update((uint)aX, (uint)aY, 1, 1);
         }
 
         /// <summary>
@@ -121,8 +122,8 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown always.</exception>
         public override void DrawArray(Color[] aColors, int aX, int aY, int aWidth, int aHeight)
         {
-            throw new NotImplementedException();
             //xSVGAIIDriver.
+            base.DrawArray(aColors, new Point(aX, aY), aWidth, aHeight);
         }
 
         /// <summary>
@@ -136,7 +137,24 @@ namespace Cosmos.System.Graphics
         public override void DrawPoint(Pen aPen, float aX, float aY)
         {
             //xSVGAIIDriver.
-            throw new NotImplementedException();
+            Color xColor = aPen.Color;
+
+            if (xColor.A == 0)
+            {
+                return;
+            }
+
+            if (xColor.A < 255)
+            {
+                xColor = AlphaBlend(xColor, GetPointColor((int)aX, (int)aY), xColor.A);
+            }
+
+            mSVGAIIDebugger.SendInternal($"Drawing point to x:{aX}, y:{aY} with {xColor.Name} Color");
+            _xSVGADriver.SetPixel((uint)aX, (uint)aY, (uint)xColor.ToArgb());
+            mSVGAIIDebugger.SendInternal($"Done drawing point");
+            /* No need to refresh all the screen to make the point appear on Screen! */
+            //xSVGAIIDriver.Update((uint)x, (uint)y, (uint)mode.Width, (uint)mode.Height);
+            //_xSVGADriver.Update((uint)aX, (uint)aY, 1, 1);
         }
 
         /// <summary>
@@ -151,7 +169,15 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown if VMWare SVGA 2 has no rectange copy capability</exception>
         public override void DrawFilledRectangle(Pen aPen, int aX_start, int aY_start, int aWidth, int aHeight)
         {
-            _xSVGADriver.Fill((uint)aX_start, (uint)aY_start, (uint)aWidth, (uint)aHeight, (uint)aPen.Color.ToArgb());
+            //_xSVGADriver.Fill((uint)aX_start, (uint)aY_start, (uint)aWidth, (uint)aHeight, (uint)aPen.Color.ToArgb());
+
+            for (uint h = 0; h < aHeight; h++)
+            {
+                for (uint w = 0; w < aWidth; w++)
+                {
+                    DrawPoint(aPen, w + aX_start, aY_start + h);
+                }
+            }
         }
 
         //public override IReadOnlyList<Mode> AvailableModes { get; } = new List<Mode>
@@ -298,8 +324,8 @@ namespace Cosmos.System.Graphics
         {
             ThrowIfModeIsNotValid(aMode);
 
-            var xWidth = (uint)aMode.Columns;
-            var xHeight = (uint)aMode.Rows;
+            var xWidth = (uint)aMode.Width;
+            var xHeight = (uint)aMode.Height;
             var xColorDepth = (uint)aMode.ColorDepth;
 
             _xSVGADriver.SetMode(xWidth, xHeight, xColorDepth);
@@ -313,7 +339,7 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown if VMWare SVGA 2 has no rectange copy capability</exception>
         public override void Clear(Color aColor)
         {
-            _xSVGADriver.Fill(0, 0, (uint)Mode.Columns, (uint)Mode.Rows, (uint)aColor.ToArgb());
+            _xSVGADriver.Clear((uint)aColor.ToArgb());
         }
 
         /// <summary>
@@ -392,7 +418,7 @@ namespace Cosmos.System.Graphics
 
         public override void Display()
         {
-            
+            _xSVGADriver.Update();
         }
     }
 }

--- a/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
+++ b/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
@@ -25,7 +25,7 @@ namespace Cosmos.System.Graphics
         /// Debugger.
         /// </summary>
         internal Debugger mSVGAIIDebugger = new Debugger("System", "SVGAIIScreen");
-
+        
         private static readonly Mode _DefaultMode = new Mode(1024, 768, ColorDepth.ColorDepth32);
 
         /// <summary>
@@ -96,8 +96,7 @@ namespace Cosmos.System.Graphics
             {
                 return;
             }
-
-            if (xColor.A < 255)
+            else if (xColor.A < 255)
             {
                 xColor = AlphaBlend(xColor, GetPointColor(aX, aY), xColor.A);
             }
@@ -106,8 +105,8 @@ namespace Cosmos.System.Graphics
             _xSVGADriver.SetPixel((uint)aX, (uint)aY, (uint)xColor.ToArgb());
             mSVGAIIDebugger.SendInternal($"Done drawing point");
             /* No need to refresh all the screen to make the point appear on Screen! */
-            //xSVGAIIDriver.Update((uint)x, (uint)y, (uint)mode.Width, (uint)mode.Height);
-            //_xSVGADriver.Update((uint)aX, (uint)aY, 1, 1);
+            //xSVGAIIDriver.Update((uint)x, (uint)y, (uint)mode.Columns, (uint)mode.Rows);
+            _xSVGADriver.Update((uint)aX, (uint)aY, 1, 1);
         }
 
         /// <summary>
@@ -122,8 +121,8 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown always.</exception>
         public override void DrawArray(Color[] aColors, int aX, int aY, int aWidth, int aHeight)
         {
+            throw new NotImplementedException();
             //xSVGAIIDriver.
-            base.DrawArray(aColors, new Point(aX, aY), aWidth, aHeight);
         }
 
         /// <summary>
@@ -137,24 +136,7 @@ namespace Cosmos.System.Graphics
         public override void DrawPoint(Pen aPen, float aX, float aY)
         {
             //xSVGAIIDriver.
-            Color xColor = aPen.Color;
-
-            if (xColor.A == 0)
-            {
-                return;
-            }
-
-            if (xColor.A < 255)
-            {
-                xColor = AlphaBlend(xColor, GetPointColor((int)aX, (int)aY), xColor.A);
-            }
-
-            mSVGAIIDebugger.SendInternal($"Drawing point to x:{aX}, y:{aY} with {xColor.Name} Color");
-            _xSVGADriver.SetPixel((uint)aX, (uint)aY, (uint)xColor.ToArgb());
-            mSVGAIIDebugger.SendInternal($"Done drawing point");
-            /* No need to refresh all the screen to make the point appear on Screen! */
-            //xSVGAIIDriver.Update((uint)x, (uint)y, (uint)mode.Width, (uint)mode.Height);
-            //_xSVGADriver.Update((uint)aX, (uint)aY, 1, 1);
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -169,15 +151,7 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown if VMWare SVGA 2 has no rectange copy capability</exception>
         public override void DrawFilledRectangle(Pen aPen, int aX_start, int aY_start, int aWidth, int aHeight)
         {
-            //_xSVGADriver.Fill((uint)aX_start, (uint)aY_start, (uint)aWidth, (uint)aHeight, (uint)aPen.Color.ToArgb());
-
-            for (uint h = 0; h < aHeight; h++)
-            {
-                for (uint w = 0; w < aWidth; w++)
-                {
-                    DrawPoint(aPen, w + aX_start, aY_start + h);
-                }
-            }
+            _xSVGADriver.Fill((uint)aX_start, (uint)aY_start, (uint)aWidth, (uint)aHeight, (uint)aPen.Color.ToArgb());
         }
 
         //public override IReadOnlyList<Mode> AvailableModes { get; } = new List<Mode>
@@ -324,8 +298,8 @@ namespace Cosmos.System.Graphics
         {
             ThrowIfModeIsNotValid(aMode);
 
-            var xWidth = (uint)aMode.Width;
-            var xHeight = (uint)aMode.Height;
+            var xWidth = (uint)aMode.Columns;
+            var xHeight = (uint)aMode.Rows;
             var xColorDepth = (uint)aMode.ColorDepth;
 
             _xSVGADriver.SetMode(xWidth, xHeight, xColorDepth);
@@ -339,7 +313,7 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown if VMWare SVGA 2 has no rectange copy capability</exception>
         public override void Clear(Color aColor)
         {
-            _xSVGADriver.Clear((uint)aColor.ToArgb());
+            _xSVGADriver.Fill(0, 0, (uint)Mode.Columns, (uint)Mode.Rows, (uint)aColor.ToArgb());
         }
 
         /// <summary>
@@ -418,7 +392,7 @@ namespace Cosmos.System.Graphics
 
         public override void Display()
         {
-            _xSVGADriver.Update();
+            
         }
     }
 }


### PR DESCRIPTION
This boolean, if true, will print info about the drive's partitions and other stuff. It was true by default and there was no option to disable it before, and we don't always need to have the info printed.

Also, don't worry about the 2 commits before, it was just me commiting to the wrong branch :v