### PR TITLE
Revert Appveyor.yml changes due to API issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,15 +60,15 @@ artifacts:
   - path: 'TestResult.xml'
 
 
-skip_commits:
-  files:
-    - Docs/
-    - .github/
-    - Artwork/
-    - '**/*.md'
-    - LICENSE.txt
-    - README.txt
-    - .gitignore
-    - source/Archive/
-    - Users/
+#skip_commits:
+#  files:
+#    - Docs/
+#    - .github/
+#    - Artwork/
+#    - '**/*.md'
+#    - LICENSE.txt
+#    - README.txt
+#    - .gitignore
+#    - source/Archive/
+#    - Users/
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ init:
 
 before_build:
   - ps: |
+      cd C:\Cosmos
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
       if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
         Write-Host "Only Markdown files were modified, skipping CI run."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,11 @@ version: 0.20150918.{build}
 image: Visual Studio 2019
 configuration: Debug-CI
 platform: Any CPU
-shallow_clone: true
 clone_folder: c:\Cosmos
 
 
-
 init:
-- cmd: |
+- ps: |
     git clone https://github.com/CosmosOS/IL2CPU.git c:\IL2CPU --depth 1
 
 install:
@@ -43,7 +41,7 @@ build_script:
 #  - Cosmos.TestRunner.UnitTest.dll
 
 test_script:
-- cmd: dotnet test Tests\Cosmos.TestRunner.UnitTest\Cosmos.TestRunner.UnitTest.csproj --logger "trx;LogFileName=c:\Cosmos\TestResult.xml"
+- ps: dotnet test Tests\Cosmos.TestRunner.UnitTest\Cosmos.TestRunner.UnitTest.csproj --logger "trx;LogFileName=c:\Cosmos\TestResult.xml"
 
 on_finish:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 install:
   - ps: |
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
-      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
+      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "md|yml$" })) {
         Write-Host "Only Markdown files were modified, skipping CI run."
         Exit-AppVeyorBuild
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,11 @@ test_script:
 
 on_finish:
 - ps: |
-    $wc = New-Object 'System.Net.WebClient'
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", "c:\Cosmos\TestResult.xml")
+    $tests = 'c:\Cosmos\TestResult.xml'
+    if (-not(Test-Path -Path $file -PathType Leaf)) {
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", $tests)
+    }
 
 notifications:
 - provider: Webhook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 install:
   - ps: |
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
-      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotLike "/Source/Archive|/Users|/Docs|/.github|/Artwork|.gitignore|md|yml|txt$" })) {
+      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotLike ".git|md|yml|txt$" })) {
         Write-Host "Only Markdown or YAML files were modified, skipping CI run."
         Exit-AppVeyorBuild
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,14 @@ platform: Any CPU
 shallow_clone: true
 clone_folder: c:\Cosmos
 
+install:
+  - ps: |
+      $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
+      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
+        Write-Host "Only Markdown files were modified, skipping CI run."
+        Exit-AppVeyorBuild
+      }
+
 init:
 - cmd: |
     git clone https://github.com/CosmosOS/IL2CPU.git c:\IL2CPU --depth 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,19 @@ platform: Any CPU
 shallow_clone: true
 clone_folder: c:\Cosmos
 
-install:
+
+
+init:
+- cmd: |
+    git clone https://github.com/CosmosOS/IL2CPU.git c:\IL2CPU --depth 1
+
+before_build:
   - ps: |
-      cd Cosmos
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
       if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
         Write-Host "Only Markdown files were modified, skipping CI run."
         Exit-AppVeyorBuild
       }
-
-init:
-- cmd: |
-    git clone https://github.com/CosmosOS/IL2CPU.git c:\IL2CPU --depth 1
 
 build_script:
 - cmd: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 install:
   - ps: |
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
-      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotLike ".git|md|yml|txt$" })) {
+      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch ".git*|md|yml|txt$" })) {
         Write-Host "Only Markdown or YAML files were modified, skipping CI run."
         Exit-AppVeyorBuild
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,9 @@ platform: Any CPU
 clone_folder: c:\Cosmos
 
 
+
 init:
-- ps: |
+- cmd: |
     git clone https://github.com/CosmosOS/IL2CPU.git c:\IL2CPU --depth 1
 
 install:
@@ -41,7 +42,7 @@ build_script:
 #  - Cosmos.TestRunner.UnitTest.dll
 
 test_script:
-- ps: dotnet test Tests\Cosmos.TestRunner.UnitTest\Cosmos.TestRunner.UnitTest.csproj --logger "trx;LogFileName=c:\Cosmos\TestResult.xml"
+- cmd: dotnet test Tests\Cosmos.TestRunner.UnitTest\Cosmos.TestRunner.UnitTest.csproj --logger "trx;LogFileName=c:\Cosmos\TestResult.xml"
 
 on_finish:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - ps: |
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
       if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch ".git*|md|yml|txt$" })) {
-        Write-Host "Only Markdown or YAML files were modified, skipping CI run."
+        Write-Host "Only metafiles were modified, skipping CI run."
         Exit-AppVeyorBuild
       }
 
@@ -47,7 +47,6 @@ test_script:
 on_finish:
 - ps: |
     $tests = "c:\Cosmos\TestResult.xml"
-    Write-Host "Check if Tests were performed on build, skipping if md/yml files edited"
     if ((Test-Path $tests)) {
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", "c:\Cosmos\TestResult.xml")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ clone_folder: c:\Cosmos
 
 install:
   - ps: |
+      cd Cosmos
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
       if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
         Write-Host "Only Markdown files were modified, skipping CI run."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,8 @@ init:
 - cmd: |
     git clone https://github.com/CosmosOS/IL2CPU.git c:\IL2CPU --depth 1
 
-before_build:
+install:
   - ps: |
-      cd C:\Cosmos
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
       if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "\.md$" })) {
         Write-Host "Only Markdown files were modified, skipping CI run."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ test_script:
 on_finish:
 - ps: |
     $tests = 'c:\Cosmos\TestResult.xml'
-    if (-not(Test-Path -Path $file -PathType Leaf)) {
+    if (-not(Test-Path -Path $tests -PathType Leaf)) {
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", $tests)
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ init:
 install:
   - ps: |
       $range = "$env:APPVEYOR_REPO_BRANCH..$env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT"
-      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotMatch "md|yml$" })) {
-        Write-Host "Only Markdown files were modified, skipping CI run."
+      if (-not (git diff --name-only --diff-filter=d $range | Where-Object { $_ -NotLike "/Source/Archive|/Users|/Docs|/.github|/Artwork|.gitignore|md|yml|txt$" })) {
+        Write-Host "Only Markdown or YAML files were modified, skipping CI run."
         Exit-AppVeyorBuild
       }
 
@@ -47,6 +47,7 @@ test_script:
 on_finish:
 - ps: |
     $tests = "c:\Cosmos\TestResult.xml"
+    Write-Host "Check if Tests were performed on build, skipping if md/yml files edited"
     if ((Test-Path $tests)) {
       $wc = New-Object 'System.Net.WebClient'
       $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", "c:\Cosmos\TestResult.xml")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,10 +46,10 @@ test_script:
 
 on_finish:
 - ps: |
-    $tests = 'c:\Cosmos\TestResult.xml'
-    if (-not(Test-Path -Path $tests -PathType Leaf)) {
+    $tests = "c:\Cosmos\TestResult.xml"
+    if ((Test-Path $tests)) {
       $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", $tests)
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/mstest/$($env:APPVEYOR_JOB_ID)", "c:\Cosmos\TestResult.xml")
     }
 
 notifications:


### PR DESCRIPTION
GitHub doesn't have a 'skipped' build status for CI providers, and only has failure or success statuses (boolean?).  AppVeyor would either need to send a succeed status to the GitHub PR in order for merging to be available, or GitHub need to add a new skipped status in its API. A webhook can be setup using a Personal Access Token to manually set the build status to 'succeeded'/'fail'