### PR TITLE
Remove before-after Run() debug lines

### DIFF
--- a/source/Cosmos.System2/Kernel.cs
+++ b/source/Cosmos.System2/Kernel.cs
@@ -113,9 +113,7 @@ namespace Cosmos.System
                 while (!mStopped)
                 {
                     //Network.NetworkStack.Update();
-                    //Global.mDebugger.Send("Really before Run");
                     Run();
-                    //Global.mDebugger.Send("Really after Run");
                 }
                 Global.mDebugger.Send("AfterRun");
                 AfterRun();

--- a/source/Cosmos.System2/Kernel.cs
+++ b/source/Cosmos.System2/Kernel.cs
@@ -113,9 +113,9 @@ namespace Cosmos.System
                 while (!mStopped)
                 {
                     //Network.NetworkStack.Update();
-                    Global.mDebugger.Send("Really before Run");
+                    //Global.mDebugger.Send("Really before Run");
                     Run();
-                    Global.mDebugger.Send("Really after Run");
+                    //Global.mDebugger.Send("Really after Run");
                 }
                 Global.mDebugger.Send("AfterRun");
                 AfterRun();


### PR DESCRIPTION
Several users found them annoying. They can be easily added manually by whoever wants them.