### PR TITLE
Update ReadNasmMapToDebugInfo.cs

### DIFF
--- a/source/Cosmos.Build.Tasks/ReadNasmMapToDebugInfo.cs
+++ b/source/Cosmos.Build.Tasks/ReadNasmMapToDebugInfo.cs
@@ -89,7 +89,7 @@ namespace Cosmos.Build.Tasks
                     }
                     else
                     {
-                        xId = DebugInfo.CreateId();
+                        xId = DebugInfo.CreateId;
                     }
                     xSource.Add(new Label()
                     {


### PR DESCRIPTION
Fix error on line 92:
CS1955: Non-invocable member 'DebugInfo.CreateId' cannot be used like a method.