### PR TITLE
Making the build tasks cross-platform

### DIFF
--- a/source/Cosmos.Build.Tasks/CreateMbr.cs
+++ b/source/Cosmos.Build.Tasks/CreateMbr.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -14,7 +15,7 @@ namespace Cosmos.Build.Tasks
         [Required]
         public bool FormatDrive { get; set; }
 
-        protected override string ToolName => "syslinux.exe";
+        protected override string ToolName => IsWindows() ? "syslinux.exe" : "syslinux";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;

--- a/source/Cosmos.Build.Tasks/ExtractMapFromElfFile.cs
+++ b/source/Cosmos.Build.Tasks/ExtractMapFromElfFile.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 using IL2CPU.Debug.Symbols;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -19,7 +20,7 @@ namespace Cosmos.Build.Tasks
         [Required]
         public string DebugInfoFile { get; set; }
 
-        protected override string ToolName => "objdump.bat";
+        protected override string ToolName => IsWindows() ? "objdump.bat" : "objdump.sh";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;

--- a/source/Cosmos.Build.Tasks/IL2CPU.cs
+++ b/source/Cosmos.Build.Tasks/IL2CPU.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -53,7 +54,7 @@ namespace Cosmos.Build.Tasks
 
         #endregion
 
-        protected override string ToolName => "IL2CPU.exe";
+        protected override string ToolName => IsWindows() ? "IL2CPU.exe" : "IL2CPU";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;
@@ -62,7 +63,7 @@ namespace Cosmos.Build.Tasks
         {
             if (String.IsNullOrWhiteSpace(ToolPath))
             {
-                return Path.Combine(CosmosBuildDir, @"IL2CPU\IL2CPU.exe");
+                return Path.Combine(CosmosBuildDir, IsWindows() ? @"IL2CPU\IL2CPU.exe" : "IL2CPU/IL2CPU");
             }
 
             return Path.Combine(Path.GetFullPath(ToolPath), ToolExe);

--- a/source/Cosmos.Build.Tasks/Ld.cs
+++ b/source/Cosmos.Build.Tasks/Ld.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -28,7 +29,7 @@ namespace Cosmos.Build.Tasks
 
         #endregion
 
-        protected override string ToolName => "ld.exe";
+        protected override string ToolName => IsWindows() ? "ld.exe" : "ld";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;

--- a/source/Cosmos.Build.Tasks/MakeIso.cs
+++ b/source/Cosmos.Build.Tasks/MakeIso.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -13,7 +14,7 @@ namespace Cosmos.Build.Tasks
         [Required]
         public string OutputFile { get; set; }
 
-        protected override string ToolName => "mkisofs.exe";
+        protected override string ToolName => IsWindows() ? "mkisofs.exe" : "mkisofs";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;

--- a/source/Cosmos.Build.Tasks/Nasm.cs
+++ b/source/Cosmos.Build.Tasks/Nasm.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -33,7 +34,7 @@ namespace Cosmos.Build.Tasks
 
         private OutputFormatEnum mOutputFormat;
 
-        protected override string ToolName => "nasm.exe";
+        protected override string ToolName => IsWindows() ? "nasm.exe" : "nasm";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;

--- a/source/Cosmos.Build.Tasks/OperatingSystem.cs
+++ b/source/Cosmos.Build.Tasks/OperatingSystem.cs
@@ -1,0 +1,9 @@
+using System.Runtime.InteropServices;
+
+namespace Cosmos.Build.Tasks
+{
+    public static class OperatingSystem
+    {
+        public static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+    }
+}

--- a/source/Cosmos.Build.Tasks/TheRingMaster.cs
+++ b/source/Cosmos.Build.Tasks/TheRingMaster.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using static Cosmos.Build.Tasks.OperatingSystem;
 
 namespace Cosmos.Build.Tasks
 {
@@ -10,7 +11,7 @@ namespace Cosmos.Build.Tasks
         [Required]
         public string KernelAssemblyPath { get; set; }
 
-        protected override string ToolName => "TheRingMaster.exe";
+        protected override string ToolName => IsWindows() ? "TheRingMaster.exe" : "TheRingMaster";
 
         protected override MessageImportance StandardErrorLoggingImportance => MessageImportance.High;
         protected override MessageImportance StandardOutputLoggingImportance => MessageImportance.High;


### PR DESCRIPTION
It's related to the IL2CPU patches for running the compiler on Non-Windows like Linux and/or Mac.
First step is to look for things like ".exe", ".bat", "\" and replace them with "", ".sh", "/" 
to allow the dotnet build task to work the same way.