### PR TITLE
Make PCSpeaker use Hal.Global pit instance

### DIFF
--- a/source/Cosmos.HAL2/PCSpeaker.cs
+++ b/source/Cosmos.HAL2/PCSpeaker.cs
@@ -20,7 +20,6 @@ namespace Cosmos.HAL
     public class PCSpeaker
     {
         protected static Core.IOGroup.PCSpeaker IO = BaseIOGroups.PCSpeaker;
-        private static PIT SpeakerPIT = new PIT();
 
         /// <summary>
         /// Enable sound.
@@ -78,7 +77,7 @@ namespace Cosmos.HAL
             }
 
             Beep(frequency);
-            SpeakerPIT.Wait(duration);
+            Global.PIT.Wait(duration);
             DisableSound();
         }
     }


### PR DESCRIPTION
Should fix #1985 