### PR TITLE
Fix VBECanvas#DrawFilledRectangle

### DIFF
--- a/source/Cosmos.System2/Graphics/VBECanvas.cs
+++ b/source/Cosmos.System2/Graphics/VBECanvas.cs
@@ -336,10 +336,10 @@ namespace Cosmos.System.Graphics
         /// <param name="aHeight">Height.</param>
         public override void DrawFilledRectangle(Pen aPen, int aX, int aY, int aWidth, int aHeight)
         {
-            //no body knows how any why but we must divide aWidth by 32, not by 8, because otherwise everything would end up 4 times the width
+            //ClearVRAM clears one uint at a time. So we clear pixelwise not byte wise. That's why we divide by 32 and not 8.
             aWidth = Math.Min(aWidth, Mode.Columns - aX) * (int)Mode.ColorDepth / 32;
 
-            for (int i = aY; i < aHeight; i++)
+            for (int i = aY; i < aY + aHeight; i++)
             {
                 _VBEDriver.ClearVRAM(GetPointOffset(aX, i), aWidth, aPen.Color.ToArgb());
             }

--- a/source/Cosmos.System2/Graphics/VBECanvas.cs
+++ b/source/Cosmos.System2/Graphics/VBECanvas.cs
@@ -336,13 +336,13 @@ namespace Cosmos.System.Graphics
         /// <param name="aHeight">Height.</param>
         public override void DrawFilledRectangle(Pen aPen, int aX, int aY, int aWidth, int aHeight)
         {
-            int xOffset = GetPointOffset(aX, aY);
             int xScreenWidthInPixel = Mode.Columns * ((int)Mode.ColorDepth / 8);
-            aWidth *= (int)Mode.ColorDepth / 8;
+            //no body knows how any why but we must divide aWidth by 32, not by 8, because otherwise everything would end up 4 times the width
+            aWidth = Math.Min(aWidth, Mode.Columns - aX) * (int)Mode.ColorDepth / 32;
 
-            for (int i = 0; i < aHeight; i++)
+            for (int i = aY; i < aHeight; i++)
             {
-                _VBEDriver.ClearVRAM((i * xScreenWidthInPixel) + xOffset, aWidth, aPen.Color.ToArgb());
+                _VBEDriver.ClearVRAM(GetPointOffset(aX, i), aWidth, aPen.Color.ToArgb());
             }
         }
 

--- a/source/Cosmos.System2/Graphics/VBECanvas.cs
+++ b/source/Cosmos.System2/Graphics/VBECanvas.cs
@@ -336,7 +336,6 @@ namespace Cosmos.System.Graphics
         /// <param name="aHeight">Height.</param>
         public override void DrawFilledRectangle(Pen aPen, int aX, int aY, int aWidth, int aHeight)
         {
-            int xScreenWidthInPixel = Mode.Columns * ((int)Mode.ColorDepth / 8);
             //no body knows how any why but we must divide aWidth by 32, not by 8, because otherwise everything would end up 4 times the width
             aWidth = Math.Min(aWidth, Mode.Columns - aX) * (int)Mode.ColorDepth / 32;
 


### PR DESCRIPTION
The previous function would draw each line without trimming it to fit the canvas width, therefore creating some weird visual bugs - the rectangle would be drawn from the left side of the screen, even though it would have gone far beyond the video mode's width.
An example of the old bug, that's now fixed: https://discord.com/channels/833970409337913344/833979135466405899/912805747597926421