### PR TITLE
Add plugs to disable intrinsics

### DIFF
--- a/Tests/Kernels/Cosmos.Compiler.Tests.Bcl.System/System/ByteTest.cs
+++ b/Tests/Kernels/Cosmos.Compiler.Tests.Bcl.System/System/ByteTest.cs
@@ -17,7 +17,9 @@ namespace Cosmos.Compiler.Tests.Bcl.System
             result = value.ToString();
             expectedResult = "255";
 
-            Assert.IsTrue((result == expectedResult), "Byte.ToString doesn't work");
+            Assert.AreEqual(result, expectedResult, "Byte.ToString doesn't work");
+            Assert.AreEqual("ff", value.ToString("x"), "Byte.ToString('x') doesn't work");
+            Assert.AreEqual("FF", value.ToString("X"), "Byte.ToString('X') doesn't work");
 
             // Now let's try to concat to a String using '+' operator
             result = "The Maximum value of a Byte is " + value;
@@ -35,14 +37,6 @@ namespace Cosmos.Compiler.Tests.Bcl.System
 
             // actually the Hash Code of a Byte is the same value expressed as int
             Assert.IsTrue((resultAsInt == value), "Byte.GetHashCode() doesn't work");
-
-#if false
-            // Now let's try ToString() again but printed in hex (this test fails for now!)
-            result = value.ToString("X2");
-            expectedResult = "FF";
-
-            Assert.IsTrue((result == expectedResult), "Byte.ToString(X2) doesn't work");
-#endif
 
             // basic bit operations
 

--- a/source/Cosmos.Core_Plugs/Runtime/Intrinsics/X86/LzcntImpl.cs
+++ b/source/Cosmos.Core_Plugs/Runtime/Intrinsics/X86/LzcntImpl.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IL2CPU.API.Attribs;
+
+namespace Cosmos.Core_Plugs.Runtime.Intrinsics.X86
+{
+    [Plug("System.Runtime.Intrinsics.X86.Lzcnt, System.Private.CoreLib")]
+    class LzcntImpl
+    {
+        public static bool get_IsSupported()
+        {
+            return false;
+        }
+    }
+
+    [Plug("System.Runtime.Intrinsics.X86.Lzcnt+X64, System.Private.CoreLib")]
+    class X64LzcntImpl
+    {
+        public static bool get_IsSupported()
+        {
+            return false;
+        }
+    }
+}

--- a/source/Cosmos.Core_Plugs/Runtime/Intrinsics/X86/X86Base.cs
+++ b/source/Cosmos.Core_Plugs/Runtime/Intrinsics/X86/X86Base.cs
@@ -10,4 +10,13 @@ namespace Cosmos.Core_Plugs.Runtime.Intrinsics.X86
             return false;
         }
     }
+
+    [Plug("System.Runtime.Intrinsics.X86.X86Base+X64, System.Private.CoreLib")]
+    class X64X86BaseImpl
+    {
+        public static bool get_IsSupported()
+        {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Fix Byte.ToString("X")
Add more byte tests