### PR TITLE
Add kernel compression

### DIFF
--- a/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
+++ b/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
@@ -13,6 +13,8 @@ namespace Cosmos.Build.Tasks
         [Required]
         public string BinName { get; set; }
 
+        public string[] Modules { get; set; }
+
         private string Indentation = "    ";
         
         public override bool Execute()
@@ -29,6 +31,13 @@ namespace Cosmos.Build.Tasks
             using (var xWriter = File.CreateText(Path.Combine(TargetDirectory + "/boot/grub/", "grub.cfg")))
             {
                 xWriter.WriteLine("set timeout=0");
+                if (Modules != null)
+                {
+                    foreach (var module in Modules)
+                    {
+                        xWriter.WriteLine($"insmod {module}");
+                    }
+                }
                 xWriter.WriteLine();
                 xWriter.WriteLine("menuentry '" + xLabelName + "' {");
                 WriteIndentedLine(xWriter, "multiboot2 /boot/" + xBinName);

--- a/source/Cosmos.Build.Tasks/Gzip.cs
+++ b/source/Cosmos.Build.Tasks/Gzip.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO.Compression;
+using System.Diagnostics;
+
+namespace Cosmos.Build.Tasks
+{
+    public class Gzip : Task
+    {
+        [Required]
+        public string BinFile { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+        
+        public override bool Execute()
+        {
+            if (!File.Exists(BinFile))
+            {
+                Log.LogError($"'{BinFile}' is missing!");
+                return false;
+            }
+
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            
+            using FileStream fileStream = File.Open(BinFile, FileMode.Open);
+            using FileStream compressedFileStream = File.Create(OutputFile);
+            using var gzip = new GZipStream(compressedFileStream, CompressionLevel.Optimal);
+            fileStream.CopyTo(gzip);
+
+            stopwatch.Stop();
+
+            int beforeMB = (int)(new FileInfo(BinFile).Length / 1024 / 1024);
+            int afterMB = (int)(new FileInfo(OutputFile).Length / 1024 / 1024);
+
+            Log.LogMessage(MessageImportance.High, $"Compressed '{BinFile}' with gzip in {stopwatch.ElapsedMilliseconds} ms ({beforeMB} MB -> {afterMB} MB)");
+
+            return true;
+        }
+    }
+}

--- a/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
+++ b/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
@@ -455,12 +455,12 @@
         <Copy SourceFiles="@(IntermediateIsoDirectory)"
               DestinationFolder="$(UsbPublishDrive)" />
 
-        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
+        <CreateGrubConfig TargetDirectory="$(UsbPublishDrive)"
                               BinName="$([System.IO.Path]::GetFileName('$(BinGzFile)'))"
                               Modules="gzio"
                               Condition="'$(CompressionType)' == 'Gzip'" />
 
-        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
+        <CreateGrubConfig TargetDirectory="$(UsbPublishDrive)"
                               BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))"
                               Condition="'$(CompressionType)' == 'None'" />
 

--- a/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
+++ b/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
@@ -7,6 +7,7 @@
 
     <PropertyGroup>
         <BinFile Condition="'$(BinFile)' == ''">$(OutputPath)$(AssemblyName).bin</BinFile>
+        <BinGzFile Condition="'$(BinGzFile)' == ''">$(OutputPath)$(AssemblyName).bin.gz</BinGzFile>
         <IsoFile Condition="'$(IsoFile)' == ''">$(OutputPath)$(AssemblyName).iso</IsoFile>
     </PropertyGroup>
 
@@ -37,9 +38,10 @@
         <DebugCom Condition="'$(DebugEnabled)' == 'False'">0</DebugCom>
 
         <BinFormat Condition="'$(BinFormat)' == ''">ELF</BinFormat>
+        <CompressionType Condition="'$(CompressionType)' == ''">None</CompressionType>
         <DebugMode Condition="'$(DebugMode)' == ''">Source</DebugMode>
         <TraceMode Condition="'$(TraceMode)' == ''">User</TraceMode>
-		<ExtractMapFile Condition="'$(ExtractMapFile)' == ''">False</ExtractMapFile>
+        <ExtractMapFile Condition="'$(ExtractMapFile)' == ''">False</ExtractMapFile>
         <StackCorruptionDetectionEnabled Condition="'$(StackCorruptionDetectionEnabled)' == ''">True</StackCorruptionDetectionEnabled>
         <StackCorruptionDetectionLevel Condition="'$(StackCorruptionDetectionLevel)' == ''">MethodFooters</StackCorruptionDetectionLevel>
         <IgnoreDebugStubAttribute Condition="'$(IgnoreDebugStubAttribute)' == ''">False</IgnoreDebugStubAttribute>
@@ -61,7 +63,7 @@
 
         <CompileVBEMultiboot Condition="'$(CompileVBEMultiboot)' == ''">False</CompileVBEMultiboot>
 
-</PropertyGroup>
+    </PropertyGroup>
 
     <PropertyGroup>
         <CosmosBuildTasksAssembly Condition="'$(CosmosBuildTasksAssembly)' == '' OR !Exists('$(CosmosBuildTasksAssembly)')">$(CosmosToolsPath)net48\Cosmos.Build.Tasks.dll</CosmosBuildTasksAssembly>
@@ -117,6 +119,7 @@
     <UsingTask TaskName="Cosmos.Build.Tasks.IL2CPU" AssemblyFile="$(CosmosBuildTasksAssembly)" />
     <UsingTask TaskName="Cosmos.Build.Tasks.Launch" AssemblyFile="$(CosmosBuildTasksAssembly)" />
     <UsingTask TaskName="Cosmos.Build.Tasks.Ld" AssemblyFile="$(CosmosBuildTasksAssembly)" />
+    <UsingTask TaskName="Cosmos.Build.Tasks.Gzip" AssemblyFile="$(CosmosBuildTasksAssembly)" />
     <UsingTask TaskName="Cosmos.Build.Tasks.MakeIso" AssemblyFile="$(CosmosBuildTasksAssembly)" />
     <UsingTask TaskName="Cosmos.Build.Tasks.Nasm" AssemblyFile="$(CosmosBuildTasksAssembly)" />
     <UsingTask TaskName="Cosmos.Build.Tasks.ReadNasmMapToDebugInfo" AssemblyFile="$(CosmosBuildTasksAssembly)" />
@@ -135,6 +138,7 @@
             Ld;
             ExtractMapFromElfFile;
             ReadNasmMapToDebugInfo;
+            Gzip;
             MakeIso
         </CosmosBuildDependsOn>
     </PropertyGroup>
@@ -295,6 +299,28 @@
 
     <!--
     ================================================================================
+                                         Gzip
+
+        [IN]
+        $(BinFile) - a binary file.
+
+        [OUT]
+		$(BinGzFile) - a gzipped binary file.
+
+    ================================================================================
+    -->
+    <Target Name="Gzip"
+            Inputs="$(BinFile)"
+            Outputs="$(BinGzFile)"
+            Condition="'$(CompressionType)' == 'Gzip'">
+
+        <Gzip BinFile="$(BinFile)"
+              OutputFile="$(BinGzFile)" />
+
+    </Target>
+
+    <!--
+    ================================================================================
                                          MakeISO
 
         [IN]
@@ -310,16 +336,17 @@
             Outputs="$(IsoFile)"
             Condition="'$(Deployment)' == 'ISO'">
 
-		    <ItemGroup>
-			    <_IsoCustomFiles Include="$(MSBuildProjectDirectory)\isoFiles\**\*.*"/>
-		    </ItemGroup>
+        <ItemGroup>
+            <_IsoCustomFiles Include="$(MSBuildProjectDirectory)\isoFiles\**\*.*"/>
+        </ItemGroup>
 
         <ItemGroup>
             <_i386pcFile Include="$(GrubPath)boot\grub\i386-pc\*" />
         </ItemGroup>
 
         <ItemGroup>
-            <_IsoFile Include="$(BinFile)" />
+            <_IsoFile Include="$(BinGzFile)" Condition="'$(CompressionType)' == 'Gzip'" />
+            <_IsoFile Include="$(BinFile)" Condition="'$(CompressionType)' == 'None'" />
             <_IsoFile Include="@(ContentToDeploy)" />
         </ItemGroup>
 
@@ -339,9 +366,16 @@
         <Copy SourceFiles="@(_i386pcFile)"
               DestinationFolder="$(IntermediateIsoDirectory)\boot\grub\i386-pc\" />
 
-        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
-                              BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))" />
 
+        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
+                              BinName="$([System.IO.Path]::GetFileName('$(BinGzFile)'))"
+                              Modules="gzio"
+                              Condition="'$(CompressionType)' == 'Gzip'" />
+        
+        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
+                              BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))"
+                              Condition="'$(CompressionType)' == 'None'" />
+        
         <MakeIso IsoDirectory="$(IntermediateIsoDirectory)"
                  OutputFile="$(IsoFile)"
                  ToolPath="$(MkisofsToolPath)"
@@ -397,7 +431,8 @@
         </ItemGroup>
 
         <ItemGroup>
-            <_UsbFile Include="$(BinFile)" />
+            <_UsbFile Include="$(BinGzFile)" Condition="'$(CompressionType)' == 'Gzip'" />
+            <_UsbFile Include="$(BinFile)" Condition="'$(CompressionType)' == 'None'" />
             <_UsbFile Include="@(ContentToDeploy)" />
         </ItemGroup>
 
@@ -420,8 +455,14 @@
         <Copy SourceFiles="@(IntermediateIsoDirectory)"
               DestinationFolder="$(UsbPublishDrive)" />
 
-        <CreateGrubConfig TargetDirectory="$(UsbPublishDrive)"
-                              BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))" />
+        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
+                              BinName="$([System.IO.Path]::GetFileName('$(BinGzFile)'))"
+                              Modules="gzio"
+                              Condition="'$(CompressionType)' == 'Gzip'" />
+
+        <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
+                              BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))"
+                              Condition="'$(CompressionType)' == 'None'" />
 
         <CreateMbr TargetDrive="$(UsbPublishDrive)"
                    FormatDrive="$(UsbPublishFormatDrive)"

--- a/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
+++ b/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
@@ -53,7 +53,7 @@
                   Category="Compile"
                   Description="Apply compression to the kernel.">
         <EnumValue Name="None" DisplayName="None"/>
-        <EnumValue Name="Gzip" DisplayName="Gzip"/>
+        <EnumValue Name="Gzip" DisplayName="gzip"/>
     </EnumProperty>
 
     <BoolProperty Name="CompileVBEMultiboot"

--- a/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
+++ b/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
@@ -48,6 +48,14 @@
         <EnumValue Name="Bin" DisplayName="Bin"/>
     </EnumProperty>
 
+    <EnumProperty Name="CompressionType"
+                  DisplayName="Compression"
+                  Category="Compile"
+                  Description="Apply compression to the kernel.">
+        <EnumValue Name="None" DisplayName="None"/>
+        <EnumValue Name="Gzip" DisplayName="Gzip"/>
+    </EnumProperty>
+
     <BoolProperty Name="CompileVBEMultiboot"
                   DisplayName="VBE Multiboot"
                   Description="Compile Cosmos with VBE information specified in Multiboot structure."


### PR DESCRIPTION
This PR adds an option to compress the kernel binary using gzip, reducing the ISO size (by around 80%, on average.)

To use:
- Open a Cosmos project's properties.
- Set Compression to gzip.

Requires https://github.com/CosmosOS/Common/pull/9