### PR TITLE
Fix SVGAII GetPixel

### DIFF
--- a/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
+++ b/source/Cosmos.HAL2/Drivers/PCI/Video/VMWareSVGAII.cs
@@ -653,7 +653,7 @@ namespace Cosmos.HAL.Drivers.PCI.Video
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         public uint GetPixel(uint x, uint y)
         {
-            return VideoMemory[((y * width + x) * depth)];
+            return VideoMemory[((y * width + x) * depth) + FrameSize];
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes following issue: https://github.com/CosmosOS/Cosmos/issues/2391

Every other canvas seems to always use the correct offset.