### PR TITLE
Fix VMWare SVGAIICanvas "Wrap-Around" Issue

### DIFF
--- a/source/Cosmos.System2/Graphics/Bitmap.cs
+++ b/source/Cosmos.System2/Graphics/Bitmap.cs
@@ -518,5 +518,32 @@ namespace Cosmos.System.Graphics
             Array.Copy(imageData, 0, file, position, imageData.Length);
             stream.Write(file, 0, file.Length);
         }
+
+        /// <summary>
+        /// Resize a bitmap
+        /// </summary>
+        /// <param name="Width">New Bitmap Width.</param>
+        /// <param name="Height">New Bitmap Height.</param>
+        /// <param name="Image">The bitmap to resize.</param>
+        /// <returns>The resized bitmap.</returns>
+        public static Cosmos.System.Graphics.Bitmap ResizeBitmap(uint Width, uint Height, Cosmos.System.Graphics.Bitmap Image)
+        {
+            if (Width <= 0 || Height <= 0 || Width == Image.Width || Height == Image.Height)
+            {
+                return Image;
+            }
+
+            Cosmos.System.Graphics.Bitmap B = new(Width, Height, Cosmos.System.Graphics.ColorDepth.ColorDepth32);
+            for (int IX = 0; IX < Image.Width; IX++)
+            {
+                for (int IY = 0; IY < Image.Height; IY++)
+                {
+                    long X = IX / (Image.Width / Width);
+                    long Y = IY / (Image.Height / Height);
+                    B.rawData[(B.Width * Y) + X] = Image.rawData[(Image.Width * IY) + IX];
+                }
+            }
+            return B;
+        }
     }
 }

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -185,6 +185,38 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         internal void DrawHorizontalLine(Pen pen, int dx, int x1, int y1)
         {
+            /*
+            if(x1 > Mode.Columns)
+            {
+                x1 = Mode.Columns;
+            }
+
+            if(y1 > Mode.Rows)
+            {
+                y1 = Mode.Rows;
+            }
+
+            if(y1 < 0)
+            {
+                y1 = 0;
+            }
+
+            if(x1 < 0)
+            {
+                 x1 = 0;
+            }
+
+            if(dx > Mode.Columns)
+            {
+                dx = Mode.Columns;
+            }
+
+            if(dx < 0)
+            {
+                 dx = 0;
+            }
+            */
+            
             int i;
 
             for (i = 0; i < dx; i++)
@@ -203,6 +235,38 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         internal void DrawVerticalLine(Pen pen, int dy, int x1, int y1)
         {
+            /*
+            if(x1 > Mode.Columns)
+            {
+                x1 = Mode.Columns;
+            }
+
+            if(y1 > Mode.Rows)
+            {
+                y1 = Mode.Rows;
+            }
+
+            if(y1 < 0)
+            {
+                y1 = 0;
+            }
+
+            if(x1 < 0)
+            {
+                 x1 = 0;
+            }
+
+            if(dy > Mode.Rows)
+            {
+                dy = Mode.Rows;
+            }
+
+            if(dy < 0)
+            {
+                 dy = 0;
+            }
+            */
+
             int i;
 
             for (i = 0; i < dy; i++)
@@ -227,6 +291,48 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         internal void DrawDiagonalLine(Pen pen, int dx, int dy, int x1, int y1)
         {
+            /*
+            if(x1 > Mode.Columns)
+            {
+                x1 = Mode.Columns;
+            }
+
+            if(y1 > Mode.Rows)
+            {
+                y1 = Mode.Rows;
+            }
+
+            if(y1 < 0)
+            {
+                y1 = 0;
+            }
+
+            if(x1 < 0)
+            {
+                 x1 = 0;
+            }
+
+            if(dx > Mode.Columns)
+            {
+                dx = Mode.Columns;
+            }
+
+            if(dx < 0)
+            {
+                 dx = 0;
+            }
+
+            if(dy > Mode.Rows)
+            {
+                dy = Mode.Rows;
+            }
+
+            if(dy < 0)
+            {
+                 dy = 0;
+            }
+            */
+
             int i, sdx, sdy, dxabs, dyabs, x, y, px, py;
 
             dxabs = Math.Abs(dx);
@@ -362,28 +468,48 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         public virtual void DrawCircle(Pen pen, int x_center, int y_center, int radius)
         {
-            if (pen == null)
-            {
-                throw new ArgumentNullException(nameof(pen));
-            }
-            ThrowIfCoordNotValid(x_center + radius, y_center);
-            ThrowIfCoordNotValid(x_center - radius, y_center);
-            ThrowIfCoordNotValid(x_center, y_center + radius);
-            ThrowIfCoordNotValid(x_center, y_center - radius);
             int x = radius;
             int y = 0;
             int e = 0;
 
+            if (pen == null)
+            {
+                throw new ArgumentNullException(nameof(pen));
+            }            
+
+            ThrowIfCoordNotValid(x_center + radius, y_center);
+            ThrowIfCoordNotValid(x_center - radius, y_center);
+            ThrowIfCoordNotValid(x_center, y_center + radius);
+            ThrowIfCoordNotValid(x_center, y_center - radius);
+
             while (x >= y)
             {
-                DrawPoint(pen, x_center + x, y_center + y);
-                DrawPoint(pen, x_center + y, y_center + x);
-                DrawPoint(pen, x_center - y, y_center + x);
-                DrawPoint(pen, x_center - x, y_center + y);
-                DrawPoint(pen, x_center - x, y_center - y);
-                DrawPoint(pen, x_center - y, y_center - x);
-                DrawPoint(pen, x_center + y, y_center - x);
-                DrawPoint(pen, x_center + x, y_center - y);
+                //DrawString(CheckIfCoordNotValid(x_center + radius, y_center) + ":" + CheckIfCoordNotValid(x_center - radius, y_center) + ":" + CheckIfCoordNotValid(x_center, y_center + radius) + ":" + CheckIfCoordNotValid(x_center, y_center - radius), Cosmos.System.Graphics.Fonts.PCScreenFont.Default, pen, new Cosmos.System.Graphics.Point(10, 10));
+                //DrawString("[X:" + x + "] [Y:" + y + "] [E:" + e + "]", Cosmos.System.Graphics.Fonts.PCScreenFont.Default, pen, new Cosmos.System.Graphics.Point(10, 10));
+
+                /*if(CheckIfCoordNotValid(x_center + radius, y_center) == true)
+                {
+                    DrawPoint(pen, x_center + x, y_center + y);     
+                    DrawPoint(pen, x_center + y, y_center - x);
+                }               
+
+                if(CheckIfCoordNotValid(x_center - radius, y_center) == true)
+                {                            
+                    DrawPoint(pen, x_center - x, y_center + y);  
+                    DrawPoint(pen, x_center + y, y_center + x);
+                }
+
+                if(CheckIfCoordNotValid(x_center, y_center + radius) == true)
+                {                    
+                    DrawPoint(pen, x_center - x, y_center - y);     
+                    DrawPoint(pen, x_center - y, y_center + x);
+                }
+
+                if(CheckIfCoordNotValid(x_center, y_center - radius) == true)
+                {
+                    DrawPoint(pen, x_center + x, y_center - y);
+                    DrawPoint(pen, x_center - y, y_center - x);
+                }*/
 
                 y++;
                 if (e <= 0)
@@ -424,7 +550,6 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         public virtual void DrawFilledCircle(Pen pen, int x0, int y0, int radius)
         {
-
             int x = radius;
             int y = 0;
             int xChange = 1 - (radius << 1);
@@ -435,7 +560,6 @@ namespace Cosmos.System.Graphics
             {
                 for (int i = x0 - x; i <= x0 + x; i++)
                 {
-
                     DrawPoint(pen, i, y0 + y);
                     DrawPoint(pen, i, y0 - y);
                 }
@@ -884,6 +1008,23 @@ namespace Cosmos.System.Graphics
             {
                 for (int _y = 0; _y < image.Height; _y++)
                 {
+                    /*
+                    if(_x + x + 2> Mode.Columns)
+                    {
+                        continue;
+                    }
+
+                    if(_y + y + 2> Mode.Rows)
+                    {
+                        continue;
+                    }
+
+                    if(y < 0 || x < 0)
+                    {
+                        continue;
+                    }
+                    */
+
                     Global.mDebugger.SendInternal(image.rawData[_x + _y * image.Width]);
                     _pen.Color = Color.FromArgb(image.rawData[_x + _y * image.Width]);
                     DrawPoint(_pen, x + _x, y + _y);
@@ -928,6 +1069,23 @@ namespace Cosmos.System.Graphics
             {
                 for (int _y = 0; _y < h; _y++)
                 {
+                    /*
+                    if(_x + x + 2> Mode.Columns)
+                    {
+                        continue;
+                    }
+
+                    if(_y + y + 2> Mode.Rows)
+                    {
+                        continue;
+                    }
+
+                    if(y < 0 || x < 0)
+                    {
+                        continue;
+                    }
+                    */
+                    
                     Global.mDebugger.SendInternal(pixels[_x + _y * w]);
                     _pen.Color = Color.FromArgb(pixels[_x + _y * w]);
                     DrawPoint(_pen, x + _x, y + _y);
@@ -951,6 +1109,21 @@ namespace Cosmos.System.Graphics
             {
                 for (int _y = 0; _y < image.Height; _y++)
                 {
+                    if(_x + x + 2> Mode.Columns)
+                    {
+                        continue;
+                    }
+
+                    if(_y + y + 2> Mode.Rows)
+                    {
+                        continue;
+                    }
+
+                    if(y < 0 || x < 0)
+                    {
+                        continue;
+                    }
+
                     Global.mDebugger.SendInternal(image.rawData[_x + _y * image.Width]);
                     _pen.Color = (Color.FromArgb(image.rawData[_x + _y * image.Width]));
                     DrawPoint(_pen, x + _x, y + _y);
@@ -1006,6 +1179,25 @@ namespace Cosmos.System.Graphics
         {
             for (int i = 0; i < str.Length; i++)
             {
+                /*
+                if(x > Mode.Columns)
+                {
+                    continue;
+                }
+
+                if(y > Mode.Rows)
+                {
+                    continue;
+                }
+
+                if(y < 0 || x < 0)
+                {
+                    continue;
+                }
+                */
+
+                Global.mDebugger.SendMessageBox(x.ToString());
+
                 DrawChar(str[i], aFont, pen, x, y);
                 x += aFont.Width;
             }
@@ -1128,6 +1320,37 @@ namespace Cosmos.System.Graphics
             {
                 throw new ArgumentOutOfRangeException(nameof(y), $"y ({y}) is not between 0 and {Mode.Rows}");
             }
+        }
+
+        /// <summary>
+        /// Check if coordinats are valid.
+        /// </summary>
+        /// <param name="point">Point on the convas.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Returns false if coords are invalid</exception>
+        protected bool CheckIfCoordNotValid(Point point)
+        {
+            return CheckIfCoordNotValid(point.X, point.Y);
+        }
+
+        /// <summary>
+        /// Check if coordinats are valid.
+        /// </summary>
+        /// <param name="x">X coordinate.</param>
+        /// <param name="y">Y coordinate.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Returns false if coords are invalid</exception>
+        protected bool CheckIfCoordNotValid(int x, int y)
+        {
+            if (x < 0 || x >= Mode.Columns)
+            {
+                return false;
+            }
+
+            if (y < 0 || y >= Mode.Rows)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/source/Cosmos.System2/Graphics/Canvas.cs
+++ b/source/Cosmos.System2/Graphics/Canvas.cs
@@ -185,38 +185,6 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         internal void DrawHorizontalLine(Pen pen, int dx, int x1, int y1)
         {
-            /*
-            if(x1 > Mode.Columns)
-            {
-                x1 = Mode.Columns;
-            }
-
-            if(y1 > Mode.Rows)
-            {
-                y1 = Mode.Rows;
-            }
-
-            if(y1 < 0)
-            {
-                y1 = 0;
-            }
-
-            if(x1 < 0)
-            {
-                 x1 = 0;
-            }
-
-            if(dx > Mode.Columns)
-            {
-                dx = Mode.Columns;
-            }
-
-            if(dx < 0)
-            {
-                 dx = 0;
-            }
-            */
-            
             int i;
 
             for (i = 0; i < dx; i++)
@@ -235,38 +203,6 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         internal void DrawVerticalLine(Pen pen, int dy, int x1, int y1)
         {
-            /*
-            if(x1 > Mode.Columns)
-            {
-                x1 = Mode.Columns;
-            }
-
-            if(y1 > Mode.Rows)
-            {
-                y1 = Mode.Rows;
-            }
-
-            if(y1 < 0)
-            {
-                y1 = 0;
-            }
-
-            if(x1 < 0)
-            {
-                 x1 = 0;
-            }
-
-            if(dy > Mode.Rows)
-            {
-                dy = Mode.Rows;
-            }
-
-            if(dy < 0)
-            {
-                 dy = 0;
-            }
-            */
-
             int i;
 
             for (i = 0; i < dy; i++)
@@ -291,48 +227,6 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         internal void DrawDiagonalLine(Pen pen, int dx, int dy, int x1, int y1)
         {
-            /*
-            if(x1 > Mode.Columns)
-            {
-                x1 = Mode.Columns;
-            }
-
-            if(y1 > Mode.Rows)
-            {
-                y1 = Mode.Rows;
-            }
-
-            if(y1 < 0)
-            {
-                y1 = 0;
-            }
-
-            if(x1 < 0)
-            {
-                 x1 = 0;
-            }
-
-            if(dx > Mode.Columns)
-            {
-                dx = Mode.Columns;
-            }
-
-            if(dx < 0)
-            {
-                 dx = 0;
-            }
-
-            if(dy > Mode.Rows)
-            {
-                dy = Mode.Rows;
-            }
-
-            if(dy < 0)
-            {
-                 dy = 0;
-            }
-            */
-
             int i, sdx, sdy, dxabs, dyabs, x, y, px, py;
 
             dxabs = Math.Abs(dx);
@@ -475,41 +369,18 @@ namespace Cosmos.System.Graphics
             if (pen == null)
             {
                 throw new ArgumentNullException(nameof(pen));
-            }            
-
-            ThrowIfCoordNotValid(x_center + radius, y_center);
-            ThrowIfCoordNotValid(x_center - radius, y_center);
-            ThrowIfCoordNotValid(x_center, y_center + radius);
-            ThrowIfCoordNotValid(x_center, y_center - radius);
+            }  
 
             while (x >= y)
             {
-                //DrawString(CheckIfCoordNotValid(x_center + radius, y_center) + ":" + CheckIfCoordNotValid(x_center - radius, y_center) + ":" + CheckIfCoordNotValid(x_center, y_center + radius) + ":" + CheckIfCoordNotValid(x_center, y_center - radius), Cosmos.System.Graphics.Fonts.PCScreenFont.Default, pen, new Cosmos.System.Graphics.Point(10, 10));
-                //DrawString("[X:" + x + "] [Y:" + y + "] [E:" + e + "]", Cosmos.System.Graphics.Fonts.PCScreenFont.Default, pen, new Cosmos.System.Graphics.Point(10, 10));
-
-                /*if(CheckIfCoordNotValid(x_center + radius, y_center) == true)
-                {
-                    DrawPoint(pen, x_center + x, y_center + y);     
-                    DrawPoint(pen, x_center + y, y_center - x);
-                }               
-
-                if(CheckIfCoordNotValid(x_center - radius, y_center) == true)
-                {                            
-                    DrawPoint(pen, x_center - x, y_center + y);  
-                    DrawPoint(pen, x_center + y, y_center + x);
-                }
-
-                if(CheckIfCoordNotValid(x_center, y_center + radius) == true)
-                {                    
-                    DrawPoint(pen, x_center - x, y_center - y);     
-                    DrawPoint(pen, x_center - y, y_center + x);
-                }
-
-                if(CheckIfCoordNotValid(x_center, y_center - radius) == true)
-                {
-                    DrawPoint(pen, x_center + x, y_center - y);
-                    DrawPoint(pen, x_center - y, y_center - x);
-                }*/
+                DrawPoint(pen, x_center + x, y_center + y);     
+                DrawPoint(pen, x_center + y, y_center - x);
+                DrawPoint(pen, x_center - x, y_center + y);  
+                DrawPoint(pen, x_center + y, y_center + x);
+                DrawPoint(pen, x_center - x, y_center - y);     
+                DrawPoint(pen, x_center - y, y_center + x);
+                DrawPoint(pen, x_center + x, y_center - y);
+                DrawPoint(pen, x_center - y, y_center - x);
 
                 y++;
                 if (e <= 0)
@@ -579,38 +450,6 @@ namespace Cosmos.System.Graphics
                     xChange += 2;
                 }
             }
-
-            /*
-            for (int y = -radius; y <= radius; y++)
-                for (int x = -radius; x <= radius; x++)
-                    if (x * x + y * y <= radius * radius)
-                        (origin.x + x, origin.y + y);
-
-
-            if (pen == null)
-                throw new ArgumentNullException(nameof(pen));
-            ThrowIfCoordNotValid(x_center + radius, y_center);
-            ThrowIfCoordNotValid(x_center - radius, y_center);
-            ThrowIfCoordNotValid(x_center, y_center + radius);
-            ThrowIfCoordNotValid(x_center, y_center - radius);
-            int x = radius;
-            int y = 0;
-            int e = 0;
-
-            while (x >= y)
-            {
-                DrawLine(pen, x_center - x, y_center + y, x_center + x, y_center + y);
-                y++;
-                if (e <= 0)
-                {
-                    e += 2 * y + 1;
-                }
-                if (e > 0)
-                {
-                    x--;
-                    e -= 2 * x + 1;
-                }
-            }*/
         }
 
         /// <summary>
@@ -645,10 +484,7 @@ namespace Cosmos.System.Graphics
             {
                 throw new ArgumentNullException(nameof(pen));
             }
-            ThrowIfCoordNotValid(x_center + x_radius, y_center);
-            ThrowIfCoordNotValid(x_center - x_radius, y_center);
-            ThrowIfCoordNotValid(x_center, y_center + y_radius);
-            ThrowIfCoordNotValid(x_center, y_center - y_radius);
+
             int a = 2 * x_radius;
             int b = 2 * y_radius;
             int b1 = b & 1;
@@ -1008,23 +844,6 @@ namespace Cosmos.System.Graphics
             {
                 for (int _y = 0; _y < image.Height; _y++)
                 {
-                    /*
-                    if(_x + x + 2> Mode.Columns)
-                    {
-                        continue;
-                    }
-
-                    if(_y + y + 2> Mode.Rows)
-                    {
-                        continue;
-                    }
-
-                    if(y < 0 || x < 0)
-                    {
-                        continue;
-                    }
-                    */
-
                     Global.mDebugger.SendInternal(image.rawData[_x + _y * image.Width]);
                     _pen.Color = Color.FromArgb(image.rawData[_x + _y * image.Width]);
                     DrawPoint(_pen, x + _x, y + _y);
@@ -1052,6 +871,7 @@ namespace Cosmos.System.Graphics
             }
             return temp;
         }
+
         /// <summary>
         /// Draw a Scaled Bitmap.
         /// </summary>
@@ -1109,7 +929,7 @@ namespace Cosmos.System.Graphics
             {
                 for (int _y = 0; _y < image.Height; _y++)
                 {
-                    if(_x + x + 2> Mode.Columns)
+                    /*if(_x + x + 2> Mode.Columns)
                     {
                         continue;
                     }
@@ -1122,7 +942,7 @@ namespace Cosmos.System.Graphics
                     if(y < 0 || x < 0)
                     {
                         continue;
-                    }
+                    }*/
 
                     Global.mDebugger.SendInternal(image.rawData[_x + _y * image.Width]);
                     _pen.Color = (Color.FromArgb(image.rawData[_x + _y * image.Width]));

--- a/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
+++ b/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
@@ -9,7 +9,7 @@ using Cosmos.System.Graphics.Fonts;
 namespace Cosmos.System.Graphics
 {
     /// <summary>
-    /// SVGAIIScreen class. Used to draw ractengales to the screen. See also: <seealso cref="Canvas"/>.
+    /// SVGAIIScreen class. Used to draw rectangles to the screen. See also: <seealso cref="Canvas"/>.
     /// </summary>
     public class SVGAIICanvas : Canvas
     {
@@ -95,6 +95,26 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         public override void DrawPoint(Pen aPen, int aX, int aY)
         {
+            /*if(aX > Mode.Columns)
+            {
+                aX = Mode.Columns;
+            }
+
+            if(aY > Mode.Rows)
+            {
+                aY = Mode.Rows;
+            }
+
+            if(aY < 0)
+            {
+                aY = 0;
+            }
+
+            if(aX < 0)
+            {
+                 aX = 0;
+            }*/
+
             if (aPen.Color.A < 255)
             {
                 if (aPen.Color.A == 0)
@@ -104,7 +124,7 @@ namespace Cosmos.System.Graphics
 
                 aPen.Color = AlphaBlend(aPen.Color, GetPointColor(aX, aY), aPen.Color.A);
             }
-
+                            
             _xSVGADriver.SetPixel((uint)aX, (uint)aY, (uint)aPen.ValueARGB);
         }
 
@@ -139,6 +159,21 @@ namespace Cosmos.System.Graphics
         }
 
         /// <summary>
+        /// Crop the width of Shapes / Images / Etc
+        /// </summary>
+        public byte[] Crop(byte[] data, uint width, uint height, uint cropWidth, uint pixelSize)
+        {
+            var output = new byte[height*cropWidth*pixelSize];
+            for(int y = 0; y<height; y++)
+            {
+                var old_offset = y * width;
+                var new_offset = y * cropWidth;
+                Array.Copy(data, old_offset, output, new_offset, new_offset);
+            }
+            return output;
+        }
+
+        /// <summary>
         /// Draw filled rectangle.
         /// </summary>
         /// <param name="aPen">Pen to draw with.</param>
@@ -150,13 +185,46 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown if VMWare SVGA 2 has no rectange copy capability</exception>
         public override void DrawFilledRectangle(Pen aPen, int aX_start, int aY_start, int aWidth, int aHeight)
         {
-            var color = aPen.Color.ToArgb();
-
-            // For now write directly into video memory, once _xSVGADriver.Fill will be faster it will have to be changed
-            for (int i = aY_start; i < aY_start + aHeight; i++)
+            try
             {
-                _xSVGADriver.VideoMemory.Fill(GetPointOffset(aX_start, i) + (int)_xSVGADriver.FrameSize, aWidth, color);
+                var color = aPen.Color.ToArgb();
+                if(aHeight > 0 && aWidth > 0 && aX_start > 0 && aY_start > 0 && (aX_start + aWidth) < Mode.Columns && (aY_start + aHeight) < Mode.Rows)
+                {                
+                    
+                }
+                else
+                {
+                    if((aX_start + aWidth) > Mode.Columns)
+                    {
+                        aWidth = Mode.Columns - aX_start;
+                    }
+                    if((aY_start + aHeight) > Mode.Rows)
+                    {
+                        aHeight = Mode.Rows - aY_start;
+                    }
+
+                    if((aX_start) < 0)
+                    {                    
+                        aWidth += aX_start;
+                        aX_start = 0;
+                    }
+                    if((aY_start) < 0)
+                    {
+                        aHeight += aY_start;
+                        aY_start = 0;
+                    }
+                }
+
+                // For now write directly into video memory, once _xSVGADriver.Fill will be faster it will have to be changed
+                for (int i = aY_start; i < aY_start + aHeight; i++)
+                {
+                    _xSVGADriver.VideoMemory.Fill(GetPointOffset(aX_start, i) + (int)_xSVGADriver.FrameSize, aWidth, color);
+                }           
             }
+            catch
+            {
+
+            } 
         }
 
         //public override IReadOnlyList<Mode> AvailableModes { get; } = new List<Mode>
@@ -376,6 +444,46 @@ namespace Cosmos.System.Graphics
         /// <exception cref="NotImplementedException">Thrown if VMWare SVGA 2 has no rectangle copy capability</exception>
         public void CopyPixel(int aX, int aY, int aNewX, int aNewY, int aWidth = 1, int aHeight = 1)
         {
+            if(aX > Mode.Columns)
+            {
+                aX = Mode.Columns;
+            }
+
+            if(aY > Mode.Rows)
+            {
+                aY = Mode.Rows;
+            }
+
+            if(aY < 0)
+            {
+                aY = 0;
+            }
+
+            if(aX < 0)
+            {
+                 aX = 0;
+            }
+
+            if(aNewX > Mode.Columns)
+            {
+                aNewX = Mode.Columns;
+            }
+
+            if(aNewY > Mode.Rows)
+            {
+                aNewY = Mode.Rows;
+            }
+
+            if(aNewY < 0)
+            {
+                aNewY = 0;
+            }
+
+            if(aNewX < 0)
+            {
+                 aNewX = 0;
+            }
+
             _xSVGADriver.Copy((uint)aX, (uint)aY, (uint)aNewX, (uint)aNewY, (uint)aWidth, (uint)aHeight);
         }
 
@@ -390,6 +498,46 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         public void MovePixel(int aX, int aY, int aNewX, int aNewY)
         {
+            if(aX > Mode.Columns)
+            {
+                aX = Mode.Columns;
+            }
+
+            if(aY > Mode.Rows)
+            {
+                aY = Mode.Rows;
+            }
+
+            if(aY < 0)
+            {
+                aY = 0;
+            }
+
+            if(aX < 0)
+            {
+                 aX = 0;
+            }
+
+            if(aNewX > Mode.Columns)
+            {
+                aNewX = Mode.Columns;
+            }
+
+            if(aNewY > Mode.Rows)
+            {
+                aNewY = Mode.Rows;
+            }
+
+            if(aNewY < 0)
+            {
+                aNewY = 0;
+            }
+
+            if(aNewX < 0)
+            {
+                 aNewX = 0;
+            }
+            
             _xSVGADriver.Copy((uint)aX, (uint)aY, (uint)aNewX, (uint)aNewY, 1, 1);
             _xSVGADriver.SetPixel((uint)aX, (uint)aY, 0);
         }
@@ -447,6 +595,21 @@ namespace Cosmos.System.Graphics
             {
                 for (byte cx = 0; cx < aFont.Width; cx++)
                 {
+                    if(cx + x > Mode.Columns)
+                    {
+                        continue;
+                    }
+
+                    if(cy + y > Mode.Rows)
+                    {
+                        continue;
+                    }
+
+                    if(y < 0 || x < 0 || cx < 0 || cy < 0)
+                    {
+                        continue;
+                    }
+
                     if (aFont.ConvertByteToBitAddres(aFont.Data[p + cy], cx + 1))
                     {
                         DrawPoint(pen, (ushort)(x + (aFont.Width - cx)), (ushort)(y + cy));
@@ -456,19 +619,48 @@ namespace Cosmos.System.Graphics
         }
 
         /// <summary>
-        /// Draw image.
+        /// Draw an image.
         /// </summary>
         /// <param name="aImage">Image.</param>
         /// <param name="aX">X coordinate.</param>
         /// <param name="aY">Y coordinate.</param>
         public override void DrawImage(Image aImage, int aX, int aY)
         {
-            var xWidth = (int)aImage.Width;
-            var xHeight = (int)aImage.Height;
-
-            for (int i = 0; i < xHeight; i++)
+            try
             {
-                _xSVGADriver.VideoMemory.Copy(GetPointOffset(aX, aY + i) + (int)_xSVGADriver.FrameSize, aImage.rawData, (i * xWidth), xWidth);
+                var xWidth = (int)aImage.Width;
+                var xHeight = (int)aImage.Height;
+
+                if((aX + aImage.Width) > Mode.Columns)
+                {
+                    aX = Convert.ToInt32(Mode.Columns - aImage.Width);
+                    aImage = Cosmos.System.Graphics.Bitmap.ResizeBitmap(Convert.ToUInt32(Mode.Columns - aX), aImage.Height, (Bitmap)aImage);
+                }
+                if((aY + aImage.Height) > Mode.Rows)
+                {
+                    aY = Convert.ToInt32(Mode.Rows - aImage.Height);
+                    aImage = Cosmos.System.Graphics.Bitmap.ResizeBitmap(aImage.Width, Convert.ToUInt32(Mode.Rows - aY), (Bitmap)aImage);
+                }
+
+                if((aX) < 0)
+                {                    
+                    aImage = Cosmos.System.Graphics.Bitmap.ResizeBitmap(Convert.ToUInt32(aImage.Width + aX), aImage.Height, (Bitmap)aImage);
+                    aX = 0;
+                }
+                if((aY) < 0)
+                {
+                    aImage = Cosmos.System.Graphics.Bitmap.ResizeBitmap(aImage.Width, Convert.ToUInt32(aImage.Height + aY), (Bitmap)aImage);
+                    aY = 0;
+                }
+
+                for (int i = 0; i < xHeight; i++)
+                {
+                    _xSVGADriver.VideoMemory.Copy(GetPointOffset(aX, aY + i) + (int)_xSVGADriver.FrameSize, aImage.rawData, (i * xWidth), xWidth);
+                }
+            }
+            catch
+            {
+
             }
         }
     }

--- a/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
+++ b/source/Cosmos.System2/Graphics/SVGAIICanvas.cs
@@ -95,25 +95,10 @@ namespace Cosmos.System.Graphics
         /// <exception cref="Exception">Thrown on memory access violation.</exception>
         public override void DrawPoint(Pen aPen, int aX, int aY)
         {
-            /*if(aX > Mode.Columns)
+            if(aX >= Mode.Columns || aY >= Mode.Rows || aY <= 0 || aX <= 0)
             {
-                aX = Mode.Columns;
+                return;
             }
-
-            if(aY > Mode.Rows)
-            {
-                aY = Mode.Rows;
-            }
-
-            if(aY < 0)
-            {
-                aY = 0;
-            }
-
-            if(aX < 0)
-            {
-                 aX = 0;
-            }*/
 
             if (aPen.Color.A < 255)
             {
@@ -198,6 +183,7 @@ namespace Cosmos.System.Graphics
                     {
                         aWidth = Mode.Columns - aX_start;
                     }
+
                     if((aY_start + aHeight) > Mode.Rows)
                     {
                         aHeight = Mode.Rows - aY_start;
@@ -208,6 +194,7 @@ namespace Cosmos.System.Graphics
                         aWidth += aX_start;
                         aX_start = 0;
                     }
+
                     if((aY_start) < 0)
                     {
                         aHeight += aY_start;
@@ -665,3 +652,4 @@ namespace Cosmos.System.Graphics
         }
     }
 }
+

--- a/source/Cosmos.System2/Graphics/VBECanvas.cs
+++ b/source/Cosmos.System2/Graphics/VBECanvas.cs
@@ -261,6 +261,28 @@ namespace Cosmos.System.Graphics
              * ColorDepth.ColorDepth16 and ColorDepth.ColorDepth8 need a conversion from color (an ARGB32 color) to the RGB16 and RGB8
              * how to do this conversion faster maybe using pre-computed tables? What happens if the color cannot be converted? We will throw?
              */
+
+
+            if(aX > Mode.Columns)
+            {
+                aX = Mode.Columns;
+            }
+
+            if(aY > Mode.Rows)
+            {
+                aY = Mode.Rows;
+            }
+
+            if(aY < 0)
+            {
+                aY = 0;
+            }
+
+            if(aX < 0)
+            {
+                 aX = 0;
+            }
+            
             switch (Mode.ColorDepth)
             {
                 case ColorDepth.ColorDepth32:

--- a/source/Cosmos.System2/Graphics/VGACanvas.cs
+++ b/source/Cosmos.System2/Graphics/VGACanvas.cs
@@ -287,21 +287,25 @@ namespace Cosmos.System.Graphics
         {
             if(aX > Mode.Columns)
             {
+                return;
                 aX = Mode.Columns;
             }
 
             if(aY > Mode.Rows)
             {
+                return;
                 aY = Mode.Rows;
             }
 
             if(aY < 0)
             {
+                return;
                 aY = 0;
             }
 
             if(aX < 0)
             {
+                return;
                  aX = 0;
             }
             

--- a/source/Cosmos.System2/Graphics/VGACanvas.cs
+++ b/source/Cosmos.System2/Graphics/VGACanvas.cs
@@ -254,6 +254,26 @@ namespace Cosmos.System.Graphics
         /// <param name="aY"></param>
         public override void DrawPoint(Pen aPen, int aX, int aY)
         {
+            if(aX > Mode.Columns)
+            {
+                aX = Mode.Columns;
+            }
+
+            if(aY > Mode.Rows)
+            {
+                aY = Mode.Rows;
+            }
+
+            if(aY < 0)
+            {
+                aY = 0;
+            }
+
+            if(aX < 0)
+            {
+                 aX = 0;
+            }
+
             _VGADriver.SetPixel((uint)aX, (uint)aY, aPen.Color);
         }
 
@@ -265,6 +285,26 @@ namespace Cosmos.System.Graphics
         /// <param name="aY"></param>
         public void DrawPoint(uint aColor, int aX, int aY)
         {
+            if(aX > Mode.Columns)
+            {
+                aX = Mode.Columns;
+            }
+
+            if(aY > Mode.Rows)
+            {
+                aY = Mode.Rows;
+            }
+
+            if(aY < 0)
+            {
+                aY = 0;
+            }
+
+            if(aX < 0)
+            {
+                 aX = 0;
+            }
+            
             _VGADriver.SetPixel((uint)aX, (uint)aY, aColor);
         }
 


### PR DESCRIPTION
This pull request fixes VMWareSVGAII Canvas "Wrap-Around" issue (Where things drawn out of screen bounds get duplicated onto the opposing side of the screen). This currently only works with the VMWareSVGAII Canvas