### PR TITLE
Minor PIT improvements

### DIFF
--- a/source/Cosmos.HAL2/PIT.cs
+++ b/source/Cosmos.HAL2/PIT.cs
@@ -282,10 +282,10 @@ namespace Cosmos.HAL
                         handler.ID = -1;
                         activeHandlers.RemoveAt(i);
                     }
-
+                    
                     handler.HandleTrigger(aContext);
                 } else {
-					handler.NSRemaining -= T0Delay;
+                    handler.NSRemaining -= T0Delay;
 				}
             }
 

--- a/source/Cosmos.HAL2/PIT.cs
+++ b/source/Cosmos.HAL2/PIT.cs
@@ -217,6 +217,7 @@ namespace Cosmos.HAL
             T2Frequency = (uint)aFreq;
         }
 
+        [Obsolete("This method has been deprecated and is equivalent to a no-op.")]
         public void MuteSound()
         {
             DisableSound();

--- a/source/Cosmos.HAL2/PIT.cs
+++ b/source/Cosmos.HAL2/PIT.cs
@@ -4,18 +4,18 @@ using Cosmos.Core;
 
 namespace Cosmos.HAL
 {
-	/// <summary>
-	/// Handles the Programmable Interval Timer (PIT).
-	/// </summary>
-	public class PIT : Device
-	{
+    /// <summary>
+    /// Handles the Programmable Interval Timer (PIT).
+    /// </summary>
+    public class PIT : Device
+    {
         /// <summary>
         /// Represents a virtual timer that can be handled using the
         /// Programmable Interrupt Timer (PIT).
         /// </summary>
-		public class PITTimer : IDisposable
-		{
-			internal int NSRemaining;
+        public class PITTimer : IDisposable
+        {
+            internal int NSRemaining;
             internal int ID = -1;
 
             /// <summary>
@@ -26,7 +26,7 @@ namespace Cosmos.HAL
             /// <summary>
             /// Whether this timer will fire once, or will fire indefinetly until unregistered.
             /// </summary>
-			public bool Recuring; // TODO: Replace with "Recurring" (typo). This would be a breaking API change.
+            public bool Recuring; // TODO: Replace with "Recurring" (typo). This would be a breaking API change.
 
             /// <summary>
             /// The ID of the timer.
@@ -36,7 +36,7 @@ namespace Cosmos.HAL
             /// <summary>
             /// The method to invoke for each cycle of the timer.
             /// </summary>
-			public OnTrigger HandleTrigger;
+            public OnTrigger HandleTrigger;
 
             /// <summary>
             /// Represents the trigger handler for a <see cref="PITTimer"/>.
@@ -51,13 +51,13 @@ namespace Cosmos.HAL
             /// <param name="callback">The method to invoke for each timer cycle.</param>
             /// <param name="nanosecondsTimeout">The delay between timer cycles.</param>
             /// <param name="recurring">Whether this timer will fire once, or will fire indefinetly until unregistered.</param>
-			public PITTimer(OnTrigger callback, int nanosecondsTimeout, bool recurring)
-			{
-				HandleTrigger = callback;
-				NanosecondsTimeout = nanosecondsTimeout;
-				NSRemaining = NanosecondsTimeout;
-				Recuring = recurring;
-			}
+            public PITTimer(OnTrigger callback, int nanosecondsTimeout, bool recurring)
+            {
+                HandleTrigger = callback;
+                NanosecondsTimeout = nanosecondsTimeout;
+                NSRemaining = NanosecondsTimeout;
+                Recuring = recurring;
+            }
 
             /// <summary>
             /// Initializes a new recurring <see cref="PITTimer"/>, with the specified
@@ -66,27 +66,27 @@ namespace Cosmos.HAL
             /// <param name="callback">The method to invoke for each timer cycle.</param>
             /// <param name="nanosecondsTimeout">The delay between timer cycles.</param>
             /// <param name="nanosecondsLeft">The amount of time left before the first timer cycle is fired.</param>
-			public PITTimer(OnTrigger callback, int nanosecondsTimeout, int nanosecondsLeft)
-			{
-				HandleTrigger = callback;
-				NanosecondsTimeout = nanosecondsTimeout;
-				NSRemaining = nanosecondsLeft;
-				Recuring = true;
-			}
+            public PITTimer(OnTrigger callback, int nanosecondsTimeout, int nanosecondsLeft)
+            {
+                HandleTrigger = callback;
+                NanosecondsTimeout = nanosecondsTimeout;
+                NSRemaining = nanosecondsLeft;
+                Recuring = true;
+            }
 
-			~PITTimer()
-			{
-				Dispose();
-			}
+            ~PITTimer()
+            {
+                Dispose();
+            }
 
-			public void Dispose()
-			{
-				if (ID != -1)
-				{
-					Global.PIT.UnregisterTimer(ID);
-				}
-			}
-		}
+            public void Dispose()
+            {
+                if (ID != -1)
+                {
+                    Global.PIT.UnregisterTimer(ID);
+                }
+            }
+        }
 
         public const uint PITFrequency = 1193180;
         public const uint PITDelayNS = 838;
@@ -94,19 +94,19 @@ namespace Cosmos.HAL
         public bool T0RateGen = false;
 
         protected Core.IOGroup.PIT IO = Core.Global.BaseIOGroups.PIT;
-		private List<PITTimer> activeHandlers = new();
-		private ushort _T0Countdown = 65535;
-		private ushort _T2Countdown = 65535;
-		private int timerCounter = 0;
-		private bool waitSignaled = false;
+        private List<PITTimer> activeHandlers = new();
+        private ushort _T0Countdown = 65535;
+        private ushort _T2Countdown = 65535;
+        private int timerCounter = 0;
+        private bool waitSignaled = false;
 
-		public PIT()
-		{
-			INTs.SetIrqHandler(0x00, HandleIRQ);
-			T0Countdown = 65535;
-		}
+        public PIT()
+        {
+            INTs.SetIrqHandler(0x00, HandleIRQ);
+            T0Countdown = 65535;
+        }
 
-		public ushort T0Countdown
+        public ushort T0Countdown
         {
             get => _T0Countdown;
             set {
@@ -129,146 +129,146 @@ namespace Cosmos.HAL
             }
         }
         public uint T0DelyNS
-		{
+        {
             get => PITDelayNS * _T0Countdown;
             set
-			{
-				if (value > 54918330)
-					throw new ArgumentException("Delay must be no greater that 54918330");
+            {
+                if (value > 54918330)
+                    throw new ArgumentException("Delay must be no greater that 54918330");
 
-				T0Countdown = (ushort)(value / PITDelayNS);
-			}
-		}
+                T0Countdown = (ushort)(value / PITDelayNS);
+            }
+        }
 
-		public ushort T2Countdown
-		{
+        public ushort T2Countdown
+        {
             get => _T2Countdown;
             set
-			{
-				_T2Countdown = value;
+            {
+                _T2Countdown = value;
 
-				IO.Command.Byte = 0xB6;
-				IO.Data0.Byte = (byte)(value & 0xFF);
-				IO.Data0.Byte = (byte)(value >> 8);
-			}
-		}
-		public uint T2Frequency
-		{
-			get => PITFrequency / ((uint)_T2Countdown);
+                IO.Command.Byte = 0xB6;
+                IO.Data0.Byte = (byte)(value & 0xFF);
+                IO.Data0.Byte = (byte)(value >> 8);
+            }
+        }
+        public uint T2Frequency
+        {
+            get => PITFrequency / ((uint)_T2Countdown);
             set
-			{
-				if (value < 19 || value > 1193180)
-				{
-					throw new ArgumentException("Frequency must be between 19 and 1193180!");
-				}
+            {
+                if (value < 19 || value > 1193180)
+                {
+                    throw new ArgumentException("Frequency must be between 19 and 1193180!");
+                }
 
-				T2Countdown = (ushort)(PITFrequency / value);
-			}
-		}
+                T2Countdown = (ushort)(PITFrequency / value);
+            }
+        }
 
-		public uint T2DelyNS
-		{
+        public uint T2DelyNS
+        {
             get => (PITDelayNS * _T2Countdown);
             set
-			{
-				if (value > 54918330)
-					throw new ArgumentException("Delay must be no greater than 54918330");
+            {
+                if (value > 54918330)
+                    throw new ArgumentException("Delay must be no greater than 54918330");
 
-				T2Countdown = (ushort)(value / PITDelayNS);
-			}
-		}
+                T2Countdown = (ushort)(value / PITDelayNS);
+            }
+        }
 
-		public void EnableSound()
-		{
-			//IO.Port61.Byte = (byte)(IO.Port61.Byte | 0x03);
-		}
+        public void EnableSound()
+        {
+            //IO.Port61.Byte = (byte)(IO.Port61.Byte | 0x03);
+        }
 
-		public void DisableSound()
-		{
-			//IO.Port61.Byte = (byte)(IO.Port61.Byte | 0xFC);
-		}
+        public void DisableSound()
+        {
+            //IO.Port61.Byte = (byte)(IO.Port61.Byte | 0xFC);
+        }
 
-		public void PlaySound(int aFreq)
-		{
-			EnableSound();
-			T2Frequency = (uint)aFreq;
-		}
+        public void PlaySound(int aFreq)
+        {
+            EnableSound();
+            T2Frequency = (uint)aFreq;
+        }
 
-		public void MuteSound()
-		{
-			DisableSound();
-		}
+        public void MuteSound()
+        {
+            DisableSound();
+        }
 
-		private void SignalWait(INTs.IRQContext irqContext)
-		{
-			waitSignaled = true;
-		}
+        private void SignalWait(INTs.IRQContext irqContext)
+        {
+            waitSignaled = true;
+        }
 
         /// <summary>
         /// Halts the CPU for the specified amount of milliseconds.
         /// </summary>
         /// <param name="timeoutMs">The amount of milliseconds to halt the CPU for.</param>
-		public void Wait(uint timeoutMs)
-		{
-			waitSignaled = false;
+        public void Wait(uint timeoutMs)
+        {
+            waitSignaled = false;
 
-			RegisterTimer(new PITTimer(SignalWait, (int)(timeoutMs * 1000000), false));
+            RegisterTimer(new PITTimer(SignalWait, (int)(timeoutMs * 1000000), false));
 
-			while (!waitSignaled)
-			{
-				Core.CPU.Halt();
-			}
-		}
+            while (!waitSignaled)
+            {
+                Core.CPU.Halt();
+            }
+        }
 
         /// <summary>
         /// Halts the CPU for the specified amount of nanoseconds.
         /// </summary>
         /// <param name="timeoutNs">The amount of nanoseconds to halt the CPU for.</param>
-		public void WaitNS(int timeoutNs)
-		{
-			waitSignaled = false;
+        public void WaitNS(int timeoutNs)
+        {
+            waitSignaled = false;
 
-			RegisterTimer(new PITTimer(SignalWait, timeoutNs, false));
+            RegisterTimer(new PITTimer(SignalWait, timeoutNs, false));
 
-			while (!waitSignaled)
-			{
-				CPU.Halt();
-			}
-		}
+            while (!waitSignaled)
+            {
+                CPU.Halt();
+            }
+        }
 
-		private void HandleIRQ(ref INTs.IRQContext aContext)
-		{
-			int T0Delay = (int)T0DelyNS;
+        private void HandleIRQ(ref INTs.IRQContext aContext)
+        {
+            int T0Delay = (int)T0DelyNS;
 
-			if (activeHandlers.Count > 0)
-			{
-				T0Countdown = 65535;
-			}
+            if (activeHandlers.Count > 0)
+            {
+                T0Countdown = 65535;
+            }
 
             PITTimer handler;
             for (int i = activeHandlers.Count - 1; i >= 0; i--)
-			{
-				handler = activeHandlers[i];
+            {
+                handler = activeHandlers[i];
 
-				handler.NSRemaining -= T0Delay;
+                handler.NSRemaining -= T0Delay;
 
-				if (handler.NSRemaining < 1)
-				{
-					if (handler.Recuring)
-					{
-						handler.NSRemaining = handler.NanosecondsTimeout;
-					}
-					else
-					{
-						handler.ID = -1;
-						activeHandlers.RemoveAt(i);
-					}
+                if (handler.NSRemaining < 1)
+                {
+                    if (handler.Recuring)
+                    {
+                        handler.NSRemaining = handler.NanosecondsTimeout;
+                    }
+                    else
+                    {
+                        handler.ID = -1;
+                        activeHandlers.RemoveAt(i);
+                    }
 
-					handler.HandleTrigger(aContext);
-				}
-			}
+                    handler.HandleTrigger(aContext);
+                }
+            }
 
-		}
+        }
 
         /// <summary>
         /// Registers a timer to this <see cref="PIT"/> object. 
@@ -276,35 +276,35 @@ namespace Cosmos.HAL
         /// <param name="timer">The target timer.</param>
         /// <returns>The newly assigned ID to the timer.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the given timer has already been registered.</exception>
-		public int RegisterTimer(PITTimer timer)
-		{
-			if (timer.ID != -1)
-			{
-				throw new InvalidOperationException("The provided timer has already been registered.");
-			}
+        public int RegisterTimer(PITTimer timer)
+        {
+            if (timer.ID != -1)
+            {
+                throw new InvalidOperationException("The provided timer has already been registered.");
+            }
 
-			timer.ID = (timerCounter++);
-			activeHandlers.Add(timer);
-			T0Countdown = 65535;
-			return timer.ID;
-		}
+            timer.ID = (timerCounter++);
+            activeHandlers.Add(timer);
+            T0Countdown = 65535;
+            return timer.ID;
+        }
 
         /// <summary>
         /// Unregisters a timer that has been previously registered to this
         /// <see cref="PIT"/> object.
         /// </summary>
         /// <param name="timerId">The ID of the timer to unregister.</param>
-		public void UnregisterTimer(int timerId)
-		{
-			for (int i = 0; i < activeHandlers.Count; i++)
-			{
-				if (activeHandlers[i].ID == timerId)
-				{
-					activeHandlers[i].ID = -1;
-					activeHandlers.RemoveAt(i);
-					return;
-				}
-			}
-		}
-	}
+        public void UnregisterTimer(int timerId)
+        {
+            for (int i = 0; i < activeHandlers.Count; i++)
+            {
+                if (activeHandlers[i].ID == timerId)
+                {
+                    activeHandlers[i].ID = -1;
+                    activeHandlers.RemoveAt(i);
+                    return;
+                }
+            }
+        }
+    }
 }

--- a/source/Cosmos.HAL2/PIT.cs
+++ b/source/Cosmos.HAL2/PIT.cs
@@ -199,11 +199,13 @@ namespace Cosmos.HAL
             }
         }
 
+        [Obsolete("This method has been deprecated and is equivalent to a no-op.")]
         public void EnableSound()
         {
             //IO.Port61.Byte = (byte)(IO.Port61.Byte | 0x03);
         }
 
+        [Obsolete("This method has been deprecated and is equivalent to a no-op.")]
         public void DisableSound()
         {
             //IO.Port61.Byte = (byte)(IO.Port61.Byte | 0xFC);

--- a/source/Cosmos.HAL2/PIT.cs
+++ b/source/Cosmos.HAL2/PIT.cs
@@ -59,6 +59,11 @@ namespace Cosmos.HAL
                 Recuring = recurring;
             }
 
+            /// <inheritdoc cref="PITTimer(OnTrigger, UInt64, Boolean)"/>
+            public PITTimer(Action callback, ulong nanosecondsTimeout, bool recurring)
+                : this(_ => callback(), nanosecondsTimeout, recurring)
+            { }
+
             /// <summary>
             /// Initializes a new recurring <see cref="PITTimer"/>, with the specified
             /// callback method and amount of nanoseconds left until the next timer cycle.
@@ -73,6 +78,11 @@ namespace Cosmos.HAL
                 NSRemaining = nanosecondsLeft;
                 Recuring = true;
             }
+
+            /// <inheritdoc cref="PITTimer(OnTrigger, UInt64, UInt64)"/>
+            public PITTimer(Action callback, ulong nanosecondsTimeout, ulong nanosecondsLeft)
+                : this(_ => callback(), nanosecondsTimeout, nanosecondsLeft)
+            { }
 
             ~PITTimer()
             {

--- a/source/Cosmos.HAL2/PIT.cs
+++ b/source/Cosmos.HAL2/PIT.cs
@@ -26,7 +26,7 @@ namespace Cosmos.HAL
             /// <summary>
             /// Whether this timer will fire once, or will fire indefinetly until unregistered.
             /// </summary>
-            public bool Recuring; // TODO: Replace with "Recurring" (typo). This would be a breaking API change.
+            public bool Recurring;
 
             /// <summary>
             /// The ID of the timer.
@@ -56,7 +56,7 @@ namespace Cosmos.HAL
                 HandleTrigger = callback;
                 NanosecondsTimeout = nanosecondsTimeout;
                 NSRemaining = NanosecondsTimeout;
-                Recuring = recurring;
+                Recurring = recurring;
             }
 
             /// <inheritdoc cref="PITTimer(OnTrigger, UInt64, Boolean)"/>
@@ -76,7 +76,7 @@ namespace Cosmos.HAL
                 HandleTrigger = callback;
                 NanosecondsTimeout = nanosecondsTimeout;
                 NSRemaining = nanosecondsLeft;
-                Recuring = true;
+                Recurring = true;
             }
 
             /// <inheritdoc cref="PITTimer(OnTrigger, UInt64, UInt64)"/>
@@ -96,6 +96,13 @@ namespace Cosmos.HAL
                     Global.PIT.UnregisterTimer(ID);
                 }
             }
+
+            #region (deprecated)
+
+            [Obsolete($"Use the {nameof(Recurring)} property instead.")]
+            public bool Recuring => Recurring;
+
+            #endregion
         }
 
         public const uint PITFrequency = 1193180;
@@ -127,6 +134,7 @@ namespace Cosmos.HAL
                 IO.Data0.Byte = (byte)(value >> 8);
             }
         }
+
         public uint T0Frequency
         {
             get => PITFrequency / (uint)_T0Countdown;
@@ -138,13 +146,14 @@ namespace Cosmos.HAL
                 T0Countdown = (ushort)(PITFrequency / value);
             }
         }
-        public uint T0DelyNS
+
+        public uint T0DelayNS
         {
             get => PITDelayNS * _T0Countdown;
-            set
-            {
-                if (value > 54918330)
+            set {
+                if (value > 54918330) {
                     throw new ArgumentException("Delay must be no greater that 54918330");
+                }
 
                 T0Countdown = (ushort)(value / PITDelayNS);
             }
@@ -162,6 +171,7 @@ namespace Cosmos.HAL
                 IO.Data0.Byte = (byte)(value >> 8);
             }
         }
+
         public uint T2Frequency
         {
             get => PITFrequency / ((uint)_T2Countdown);
@@ -176,13 +186,14 @@ namespace Cosmos.HAL
             }
         }
 
-        public uint T2DelyNS
+        public uint T2DelayNS
         {
             get => (PITDelayNS * _T2Countdown);
             set
             {
-                if (value > 54918330)
+                if (value > 54918330) {
                     throw new ArgumentException("Delay must be no greater than 54918330");
+                }
 
                 T2Countdown = (ushort)(value / PITDelayNS);
             }
@@ -248,7 +259,7 @@ namespace Cosmos.HAL
 
         private void HandleIRQ(ref INTs.IRQContext aContext)
         {
-            ulong T0Delay = T0DelyNS;
+            ulong T0Delay = T0DelayNS;
 
             if (activeHandlers.Count > 0)
             {
@@ -262,7 +273,7 @@ namespace Cosmos.HAL
 				
                 if (handler.NSRemaining <= T0Delay)
                 {
-                    if (handler.Recuring)
+                    if (handler.Recurring)
                     {
                         handler.NSRemaining = handler.NanosecondsTimeout;
                     }
@@ -316,5 +327,15 @@ namespace Cosmos.HAL
                 }
             }
         }
+
+        #region (deprecated)
+
+        [Obsolete($"Use the {nameof(T0DelayNS)} property instead.")]
+        public uint T0DelyNS => T0DelayNS;
+
+        [Obsolete($"Use the {nameof(T2DelayNS)} property instead.")]
+        public uint T2DelyNS => T2DelayNS;
+
+        #endregion
     }
 }


### PR DESCRIPTION
This PR adds minor improvements to the PIT:
- minor formatting changes
- added documentation
- ability to read the CPU state when the timer interrupt has occurred, allowing for things like basic preemptive multitasking
- timeouts changed from signed 32-bit integers to unsigned 64-bit integers, allowing for higher delays between each timer cycle