### PR TITLE
Add option to set GRUB boot timeout

### DIFF
--- a/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
+++ b/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -28,7 +29,7 @@ namespace Cosmos.Build.Tasks
             }
 
             var xBinName = BinName;
-            var xLabelName = Path.GetFileNameWithoutExtension(xBinName).remove;
+            var xLabelName = Path.GetFileNameWithoutExtension(xBinName);
 
             using (var xWriter = File.CreateText(Path.Combine(TargetDirectory + "/boot/grub/", "grub.cfg")))
             {

--- a/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
+++ b/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
@@ -18,7 +18,7 @@ namespace Cosmos.Build.Tasks
 
         private string Indentation = "    ";
 
-        public string timeout { get; set; }
+        public string Timeout { get; set; }
         
         public override bool Execute()
         {
@@ -33,9 +33,9 @@ namespace Cosmos.Build.Tasks
 
             using (var xWriter = File.CreateText(Path.Combine(TargetDirectory + "/boot/grub/", "grub.cfg")))
             {
-                if (!String.IsNullOrWhiteSpace(timeout) && !String.IsNullOrEmpty(timeout))
+                if (!String.IsNullOrWhiteSpace(Timeout) && !String.IsNullOrEmpty(Timeout))
                 {
-                    xWriter.WriteLine("set timeout=" + timeout);
+                    xWriter.WriteLine("set timeout=" + Timeout);
                 }
                 else
                 {

--- a/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
+++ b/source/Cosmos.Build.Tasks/CreateGrubConfig.cs
@@ -16,6 +16,8 @@ namespace Cosmos.Build.Tasks
         public string[] Modules { get; set; }
 
         private string Indentation = "    ";
+
+        public string timeout { get; set; }
         
         public override bool Execute()
         {
@@ -26,11 +28,18 @@ namespace Cosmos.Build.Tasks
             }
 
             var xBinName = BinName;
-            var xLabelName = Path.GetFileNameWithoutExtension(xBinName);
+            var xLabelName = Path.GetFileNameWithoutExtension(xBinName).remove;
 
             using (var xWriter = File.CreateText(Path.Combine(TargetDirectory + "/boot/grub/", "grub.cfg")))
             {
-                xWriter.WriteLine("set timeout=0");
+                if (!String.IsNullOrWhiteSpace(timeout) && !String.IsNullOrEmpty(timeout))
+                {
+                    xWriter.WriteLine("set timeout=" + timeout);
+                }
+                else
+                {
+                    xWriter.WriteLine("set timeout=0");
+                }
                 if (Modules != null)
                 {
                     foreach (var module in Modules)
@@ -38,6 +47,7 @@ namespace Cosmos.Build.Tasks
                         xWriter.WriteLine($"insmod {module}");
                     }
                 }
+
                 xWriter.WriteLine();
                 xWriter.WriteLine("menuentry '" + xLabelName + "' {");
                 WriteIndentedLine(xWriter, "multiboot2 /boot/" + xBinName);

--- a/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
+++ b/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
@@ -383,12 +383,12 @@
         <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
                               BinName="$([System.IO.Path]::GetFileName('$(BinGzFile)'))"
                               Modules="gzio"
-                              timeout="$(Timeout)"
+                              Timeout="$(Timeout)"
                               Condition="'$(CompressionType)' == 'Gzip'" />
         
         <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
                               BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))"
-                              timeout="$(Timeout)"
+                              Timeout="$(Timeout)"
                               Condition="'$(CompressionType)' == 'None'" />
         
         <MakeIso IsoDirectory="$(IntermediateIsoDirectory)"

--- a/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
+++ b/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
@@ -70,9 +70,9 @@
 
         <CompileVBEMultiboot Condition="'$(CompileVBEMultiboot)' == ''">False</CompileVBEMultiboot>
 
-
         <RemoveBootDebugOutput Condition="'$(RemoveBootDebugOutput)' == ''">ELF</RemoveBootDebugOutput>
-	      <OptimizationLevel Condition="'$(OptimizationLevel)' == ''">1</OptimizationLevel>
+
+        <OptimizationLevel Condition="'$(OptimizationLevel)' == ''">1</OptimizationLevel>
 
     </PropertyGroup>
 
@@ -383,10 +383,12 @@
         <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
                               BinName="$([System.IO.Path]::GetFileName('$(BinGzFile)'))"
                               Modules="gzio"
+                              timeout="$(Timeout)"
                               Condition="'$(CompressionType)' == 'Gzip'" />
         
         <CreateGrubConfig TargetDirectory="$(IntermediateIsoDirectory)"
                               BinName="$([System.IO.Path]::GetFileName('$(BinFile)'))"
+                              timeout="$(Timeout)"
                               Condition="'$(CompressionType)' == 'None'" />
         
         <MakeIso IsoDirectory="$(IntermediateIsoDirectory)"

--- a/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
+++ b/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
@@ -76,9 +76,16 @@
                   <EnumValue Name="1" DisplayName="O1"/>
                   <EnumValue Name="2" DisplayName="O2"/>
                   <EnumValue Name="3" DisplayName="O3 (Unstable)"/>
-	      <EnumValue Name="s" DisplayName="Os (Unstable)"/>
-	      <EnumValue Name="fast" DisplayName="Ofast (Unstable)"/>
+	          <EnumValue Name="s" DisplayName="Os (Unstable)"/>
+	          <EnumValue Name="fast" DisplayName="Ofast (Unstable)"/>
     </EnumProperty>
+
+    <StringProperty Name="Timeout"
+                    DisplayName="GRUB Menu Timeout"
+                    Description="The time to wait (in seconds) before the kernel is automatically started."
+                    Category="Compile"
+		    Default="0">
+    </StringProperty>
 
     <StringProperty Name="VBEResolution"
                     DisplayName="VBE Resolution"


### PR DESCRIPTION
I've added the option to change the GRUB boot timeout because I think it could be useful during debugging. If the value isn't set it will default to 0 seconds.