### PR TITLE
Include X# comments option in properties

### DIFF
--- a/source/Cosmos.Build.Tasks/IL2CPU.cs
+++ b/source/Cosmos.Build.Tasks/IL2CPU.cs
@@ -56,6 +56,8 @@ namespace Cosmos.Build.Tasks
 
         public bool RemoveBootDebugOutput { get; set; }
 
+        public bool AllowComments { get; set; }
+
         public string VBEResolution { get; set; }
 
         #endregion
@@ -68,6 +70,7 @@ namespace Cosmos.Build.Tasks
         public IL2CPU()
         {
             CompileVBEMultiboot = false;
+            AllowComments = false;
             VBEResolution = "800x600x32";
         }
 
@@ -99,7 +102,8 @@ namespace Cosmos.Build.Tasks
                 ["IgnoreDebugStubAttribute"] = IgnoreDebugStubAttribute.ToString(),
                 ["CompileVBEMultiboot"] = CompileVBEMultiboot.ToString(),
                 ["VBEResolution"] = VBEResolution.ToString(),
-                ["RemoveBootDebugOutput"] = RemoveBootDebugOutput.ToString()
+                ["RemoveBootDebugOutput"] = RemoveBootDebugOutput.ToString(),
+                ["AllowComments"] = AllowComments.ToString()
             }.ToList();
 
             foreach (var reference in References)

--- a/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
+++ b/source/Cosmos.Build.Tasks/build/Cosmos.Build.targets
@@ -72,6 +72,8 @@
 
         <RemoveBootDebugOutput Condition="'$(RemoveBootDebugOutput)' == ''">ELF</RemoveBootDebugOutput>
 
+        <AllowComments Condition="'$(AllowComments)' == ''">False</AllowComments>
+
         <OptimizationLevel Condition="'$(OptimizationLevel)' == ''">1</OptimizationLevel>
     </PropertyGroup>
 
@@ -205,7 +207,8 @@
                 ToolPath="$(Il2cpuToolPath)"
                 ToolExe="$(Il2cpuToolExe)"
                 CompileVBEMultiboot="$(CompileVBEMultiboot)"
-				VBEResolution="$(VBEResolution)"/>
+				AllowComments="$(AllowComments)"
+                VBEResolution="$(VBEResolution)"/>
 
     </Target>
 

--- a/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
+++ b/source/Cosmos.VS.ProjectSystem/BuildSystem/Rules/CosmosPropertyPage.xaml
@@ -68,6 +68,12 @@
                   Category="Compile">
     </BoolProperty>
 
+    <BoolProperty Name="AllowComments"
+                  DisplayName="Allow X# Comments"
+                  Description="Include comments in the final assembly. Enabling this will increase compile times."
+                  Category="Compile">
+    </BoolProperty>
+
     <EnumProperty Name="OptimizationLevel"
 		  DisplayName="Optimization Level"
                   Description="Choose the optimization level that you want to use."


### PR DESCRIPTION
This PR adds a new option in the project properties to allow X# comments. By default, it is disabled for faster compile times.