### PR TITLE
Close VMware Workstation properly from debug engine

### DIFF
--- a/source/Cosmos.Debug.Hosts/VMware.cs
+++ b/source/Cosmos.Debug.Hosts/VMware.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.Win32;
@@ -106,9 +107,13 @@ namespace Cosmos.Debug.Hosts {
       }
 
       // Get the new processes
-      for (int i = mProcessesBefore.Length; i < mProcessesAfter.Length; i++)
+      for (int i = 0; i < mProcessesAfter.Length; i++)
       {
-        mProcesses.Add(mProcessesAfter[i]);
+        Process process = mProcessesAfter[i];
+        if (process.Id != mProcessesBefore[i].Id)
+        {
+          mProcesses.Add(process);
+        }
       }
     }
 

--- a/source/Cosmos.Debug.Hosts/VMware.cs
+++ b/source/Cosmos.Debug.Hosts/VMware.cs
@@ -96,10 +96,18 @@ namespace Cosmos.Debug.Hosts {
       mProcessesBefore = Process.GetProcessesByName("vmware-vmx");
       mProcess.Start();
 
+      Stopwatch watch = Stopwatch.StartNew();
+
       // Wait for the process to spawn
       mProcessesAfter = Process.GetProcessesByName("vmware-vmx");
       while (mProcessesAfter.Length == mProcessesBefore.Length)
       {
+        if (watch.Elapsed.Seconds == 15)
+        {
+          watch.Stop();
+          throw new TimeoutException("VMware Workstation took too long to launch!");
+        }
+
         mProcessesAfter = Process.GetProcessesByName("vmware-vmx");
       }
 

--- a/source/Cosmos.Debug.Hosts/VMware.cs
+++ b/source/Cosmos.Debug.Hosts/VMware.cs
@@ -16,8 +16,7 @@ namespace Cosmos.Debug.Hosts {
     protected string mDir;
     protected string mVmxPath;
     protected Process mProcess;
-    protected Process[] mProcessesBefore, mProcessesAfter;
-    protected List<Process> mProcesses;
+    protected Process[] mProcessesBefore, mProcessesAfter, mProcesses;
     protected string mWorkstationPath;
     protected string mPlayerPath;
     protected string mHarddisk;
@@ -26,8 +25,6 @@ namespace Cosmos.Debug.Hosts {
       mHarddisk = harddisk;
       mDir = Path.Combine(CosmosPaths.Build, @"VMWare\Workstation\");
       mVmxPath = Path.Combine(mDir, @"Debug.vmx");
-
-      mProcesses = new List<Process>();
 
       mWorkstationPath = GetPathname("VMware Workstation", "vmware.exe");
       mPlayerPath = GetPathname("VMware Player", "vmplayer.exe");
@@ -107,14 +104,7 @@ namespace Cosmos.Debug.Hosts {
       }
 
       // Get the new processes
-      for (int i = 0; i < mProcessesAfter.Length; i++)
-      {
-        Process process = mProcessesAfter[i];
-        if (process.Id != mProcessesBefore[i].Id)
-        {
-          mProcesses.Add(process);
-        }
-      }
+      mProcesses = mProcessesBefore.Concat(mProcessesAfter).Distinct().ToArray();
     }
 
     private void ExitCallback(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #2259

This PR makes it so that VMware Workstation is properly closed from the debug engine. This is done by comparing the number of vmware-vmx.exe processes before and after the VM is launched. It then gets the vmware-vmx processes launched alongside the VM, and adds them to a list, which then the debug engine uses to kill those running processes when it stops.

This is not a perfect solution (another VM could be launched at the exact same time as Cosmos and still be detected by the debug engine), but this is much better than just killing every single vmware-vmx process.