### PR TITLE
Made OnBoot.md a bit more detailed, and Startup.md alot more detailed.

### DIFF
--- a/Docs/articles/Kernel/OnBoot.md
+++ b/Docs/articles/Kernel/OnBoot.md
@@ -1,15 +1,15 @@
 # OnBoot
-If you need to disable drivers because you are developing your own you may do so by adding the OnBoot method to your kernel, 
-right now you can disable 3 drivers and disable one part of a driver, an example would be
+If you need to disable drivers because you are developing your own, or in some cases just don't need them, you may do so by adding the OnBoot method to your kernel. For now, you can disable 3 drivers and disable a part of a driver, an example would be
 
 ```csharp
-public override void OnBoot() {
-Sys.Global.Init(GetTextScreen(),true,true,true,false);
+protected override void OnBoot() {
+    Sys.Global.Init(GetTextScreen(),true,true,true,false);
 }
 ```
-in the above example we specify that the mousewheel is enabled, the ps2controller is loaded, network drivers are being loaded and the IDE controller is disabled.
+
+In that example, we specify that the mousewheel is enabled, the PS2controller is loaded, network drivers are being loaded and the IDE controller is disabled.
 this is helpful if you intend on developing your own IDE controller, the order of the booleans is as stated above:
-Mousewheel,
-PS2Controller,
-Network Drivers,
-IDE Controller
+`Mousewheel`
+`PS2Controller`
+`Network Drivers`
+`IDE Controller`

--- a/Docs/articles/Kernel/Startup.md
+++ b/Docs/articles/Kernel/Startup.md
@@ -1,7 +1,19 @@
 # Startup
 
-On startup, there is some hand-coded assembly that runs before the Cosmos layer kicks in. From there, the C# entry point Cosmos.System.Kernel.Start(); or Sys.Kernel.Start(); is called.
+On startup, the first thing that happens is that the BIOS of your computer loads Limine, the bootloader that Cosmos uses. From there, there is some hand-coded assembly that runs before the "Cosmos layer" kicks in. From there, the IL2CPU-ed C# entry point `Cosmos.System.Kernel.Start()` or `Sys.Kernel.Start()` is called.
 
-Cosmos.System.Kernel is an abstract class that forms the Cosmos framework upon which your OS is built upon.
+> By the way, `Cosmos.System.Kernel` is an abstract class that forms the Cosmos framework. It provides a base that your OS is built on top of.
 
-You can override the Kernel.Start() method to suppress the standard Cosmos boot routines.
+## Sys.Kernel.Start()
+
+### What does it do?
+`Kernel.Start()` does quite a bit of stuff. First, it checks if `System.String.Empty` was not... Uhh, thrown away by the compiler. Then it initializes the hardware bootstrap, then calls `OnBoot()`.
+> We have an article explaining what `OnBoot()` is.
+
+Then, `Kernel.Start()` calls your `BeforeRun()` method, after it finishes, `Kernel.Start()` enables the hardware interrupts. Then it simply does a `while (!mStopped)` loop with your `Run()` method. After that, it calls an optional method called `AfterRun()`. By default, `AfterRun()` is just empty, so don't worry about nulls or something like that. Then it finishes. All of that is also try/catched too with the `A kernel exception has occurred` message.
+
+### Overriding it
+You can override the `Kernel.Start()` method in your Kernel to suppress the standard Cosmos boot routines and get deeper control of Cosmos.
+> You override it the same way you do with other methods. An extremely simple base override in your Kernel would be: `protected override void Start() {}`
+
+The default `Kernel.Start()` method is located in `Cosmos\source\Cosmos.System2\Kernel.cs`. You can copy it and make modifications with your Kernel override.


### PR DESCRIPTION
This PR updates the OnBoot.md and Startup.md documentation to improve clarity and accuracy.

In OnBoot.md, the example has been fixed and the switchable option list has been separated into separate code blocks for better readability.

In Startup.md, the documentation has been revamped to provide more detail on the boot process. There is also some words added about the BIOS and bootloader. The Sys.Kernel.Start() method has also been explained in greater detail, including a "What does it do?" section and an "Overriding it" section. Additionally, code blocks have been added where necessary to improve readability.