### PR TITLE
Made Startup.md a bit more formal in the String.Empty section

### DIFF
--- a/Docs/articles/Kernel/Startup.md
+++ b/Docs/articles/Kernel/Startup.md
@@ -7,7 +7,7 @@ On startup, the first thing that happens is that the BIOS of your computer loads
 ## Sys.Kernel.Start()
 
 ### What does it do?
-`Kernel.Start()` does quite a bit of stuff. First, it checks if `System.String.Empty` was not... Uhh, thrown away by the compiler. Then it initializes the hardware bootstrap, then calls `OnBoot()`.
+`Kernel.Start()` does quite a bit of stuff. First, it checks if `System.String.Empty` is null. If it is null, then it will just throw an exception. If it isn't, it just continues. After that check, `Kernel.Start()` initializes the hardware bootstrap, then calls `OnBoot()`.
 > We have an article explaining what `OnBoot()` is.
 
 Then, `Kernel.Start()` calls your `BeforeRun()` method, after it finishes, `Kernel.Start()` enables the hardware interrupts. Then it simply does a `while (!mStopped)` loop with your `Run()` method. After that, it calls an optional method called `AfterRun()`. By default, `AfterRun()` is just empty, so don't worry about nulls or something like that. Then it finishes. All of that is also try/catched too with the `A kernel exception has occurred` message.


### PR DESCRIPTION
All this PR does is change this section in Startup.md:

>  First, it checks if `System.String.Empty` was not... Uhh, thrown away by the compiler.

Into this:

> First, it checks if `System.String.Empty` is null. If it is null, then it will just throw an exception. If it isn't, it just continues.

This is to make the documentation a bit more formal.