### PR TITLE
Convert object to string in ConsoleImpl.Write(object) and ConsoleImpl.WriteLine(object)

### DIFF
--- a/source/Cosmos.System2_Plugs/System/ConsoleImpl.cs
+++ b/source/Cosmos.System2_Plugs/System/ConsoleImpl.cs
@@ -506,7 +506,7 @@ namespace Cosmos.System_Plugs.System
         public static void WriteLine(long aLong) => WriteLine(aLong.ToString());
 
         /* Correct behaviour printing null should not throw NRE or do nothing but should print an empty line */
-        public static void WriteLine(object value) => Write((value ?? string.Empty) + Environment.NewLine);
+        public static void WriteLine(object value) => Write((value ?? string.Empty).ToString() + Environment.NewLine);
 
         public static void WriteLine(string aText) => Write(aText + Environment.NewLine);
 
@@ -558,7 +558,7 @@ namespace Cosmos.System_Plugs.System
         public static void Write(long aLong) => Write(aLong.ToString());
 
         /* Correct behaviour printing null should not throw NRE or do nothing but should print an empty string */
-        public static void Write(object value) => Write(value ?? string.Empty);
+        public static void Write(object value) => Write((value ?? string.Empty).ToString());
 
         public static void Write(string aText)
         {


### PR DESCRIPTION
Before, if you would pass an object to Console.Write or Console.WriteLine without converting it to a string, it would hang the system and output a mess of a color fest (at least in my case).

This was easily fixed by calling ToString on the object, which makes the Write (and WriteLine) method behave as it should.