### PR TITLE
Fix ISO9660

### DIFF
--- a/source/Cosmos.System2/FileSystem/Disk.cs
+++ b/source/Cosmos.System2/FileSystem/Disk.cs
@@ -25,6 +25,21 @@ namespace Cosmos.System.FileSystem
             get
             {
                 List<ManagedPartition> converted = new();
+
+                if(Host.Type == BlockDeviceType.RemovableCD) {
+                    // we dont actually have a partition table in CDs
+                    ManagedPartition part = new(new Partition(Host, 0, Host.BlockCount / 4)); // BlockSize is 512, SectorSize of ISO9660 usually is 2 2048
+
+                    if (mountedPartitions[0] != null) {
+                        var data = mountedPartitions[0];
+                        part.RootPath = data.RootPath;
+                        part.MountedFS = data;
+                    }
+
+                    converted.Add(part);
+                    return converted;
+                }
+
                 if (GPT.IsGPTPartition(Host))
                 {
                     GPT gpt = new(Host);

--- a/source/Cosmos.System2/FileSystem/ISO9660/ISO9660FileSystem.cs
+++ b/source/Cosmos.System2/FileSystem/ISO9660/ISO9660FileSystem.cs
@@ -204,16 +204,18 @@ namespace Cosmos.System.FileSystem.ISO9660
             foreach (var item in dirEntries)
             {
                 DirectoryEntryTypeEnum type;
+                var fName = item.FileID;
+
                 if ((item.FileFlags & (1 << 1)) != 0)
                 {
                     type = DirectoryEntryTypeEnum.Directory;
                 }
                 else
                 {
-                    type = DirectoryEntryTypeEnum.File;
+                    type = DirectoryEntryTypeEnum.File; //remove the ;1 part from the file name
+                    fName = fName.Remove(fName.Length - 2);
                 }
-                var properID = item.FileID.Remove(item.FileID.Length - 2); //remove the ;1 part from the file name
-                entries.Add(new ISO9660DirectoryEntry(item, this, parent, Path.Combine(parent.mFullPath, properID), properID, 0, type));
+                entries.Add(new ISO9660DirectoryEntry(item, this, parent, Path.Combine(parent.mFullPath, fName), fName, 0, type));
             }
             return entries;
         }


### PR DESCRIPTION
Fixes ISO9660


It was caused by the VFSManager looking for partitions, but on a CD there usually are no partitions. So I just made CDs act like one big partition and this fixed the problem

![image](https://github.com/CosmosOS/Cosmos/assets/49924528/d2bb9c9e-884e-47cf-9ae1-74d0e88dfdc1)
