### PR TITLE
Fix Cosmos.Build.Tasks target

### DIFF
--- a/source/Cosmos.Build.Tasks/Cosmos.Build.Tasks.csproj
+++ b/source/Cosmos.Build.Tasks/Cosmos.Build.Tasks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <PackageId>Cosmos.Build</PackageId>
         <PackageDescription>Cosmos build system.</PackageDescription>
         <IsMSBuildExtensionProject>True</IsMSBuildExtensionProject>


### PR DESCRIPTION
Changing it to x86 seems to have broken the devkit. 