### PR TITLE
Fix cosmos build and recongition error

### DIFF
--- a/source/Cosmos.Build.Builder/packages.lock.json
+++ b/source/Cosmos.Build.Builder/packages.lock.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.VisualStudio.Setup.Configuration.Interop": {
+        "type": "Direct",
+        "requested": "[1.16.30, )",
+        "resolved": "1.16.30",
+        "contentHash": "lC6SqNkraWUSY7cyF5GUmXSECoTMwslBc/r1dguChjsi0D0BlF7G6PLsvXD0NFCwnpKlgVzUYrIq7DQakdGerw=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, )",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "NuGet.Common": {
+        "type": "Direct",
+        "requested": "[5.9.1, )",
+        "resolved": "5.9.1",
+        "contentHash": "BRX0V8k8QXcEWL33V2HcBU1+eu/Qp5LDJlheYFSZ03hKjlHVHFfLquvUUYLgSNO7tiBxCFe7pTSgO4XanyzteQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.9.1"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Direct",
+        "requested": "[5.9.1, )",
+        "resolved": "5.9.1",
+        "contentHash": "dpjLDYEuhR1J8L3s9c1qVHEBaWqFI2/x3qRmhqVYDLB5B9ETVe1jVkxLkFQreQVgh+N5cVgtZWx1jGuArj7QaQ==",
+        "dependencies": {
+          "NuGet.Common": "5.9.1"
+        }
+      },
+      "System.Runtime.WindowsRuntime": {
+        "type": "Direct",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "IWrs1TmbxP65ZZjIglNyvDkFNoV5q2Pofg5WO7I8RKQOpLdFprQSh3xesOoClBqR4JHr4nEB1Xk1MqLPW1jPuQ=="
+      },
+      "WPF-UI": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "1e9Q8pQGfi9YFp3WavKZjXyLYohIjXxk5q0NqEaamofVgIdxRxwqrkWha584FBUISRBBT/qFOrl97YBl5bs30Q==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.9.1",
+        "contentHash": "LuJA875MQpPMdik6KUsDUnEDSXWX+T/sExFikA0A5zGFkEW37weP5b6NxljWlrw4UNOWTgmTeumm802Jwz20sw=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg=="
+      }
+    },
+    ".NETFramework,Version=v4.7.2/win7-x86": {}
+  }
+}

--- a/source/Cosmos.Build.Tasks/packages.lock.json
+++ b/source/Cosmos.Build.Tasks/packages.lock.json
@@ -255,7 +255,7 @@
         }
       }
     },
-    ".NETFramework,Version=v4.8/win-x86": {
+    ".NETFramework,Version=v4.8/win-x64": {
       "Microsoft.Win32.Registry": {
         "type": "Transitive",
         "resolved": "5.0.0",

--- a/source/Cosmos.Deploy.Pixie/Cosmos.Deploy.Pixie.csproj
+++ b/source/Cosmos.Deploy.Pixie/Cosmos.Deploy.Pixie.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0-windows</TargetFramework>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <OutputType>WinExe</OutputType>
         <ApplicationIcon>Cosmos.ico</ApplicationIcon>
         <UseWPF>true</UseWPF>

--- a/source/Cosmos.Deploy.Pixie/packages.lock.json
+++ b/source/Cosmos.Deploy.Pixie/packages.lock.json
@@ -2,6 +2,6 @@
   "version": 1,
   "dependencies": {
     "net6.0-windows7.0": {},
-    "net6.0-windows7.0/win-x86": {}
+    "net6.0-windows7.0/win-x64": {}
   }
 }

--- a/source/Cosmos.Deploy.USB/Cosmos.Deploy.USB.csproj
+++ b/source/Cosmos.Deploy.USB/Cosmos.Deploy.USB.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0-windows</TargetFramework>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <OutputType>WinExe</OutputType>
         <ApplicationIcon>Cosmos.ico</ApplicationIcon>
         <UseWPF>true</UseWPF>

--- a/source/Cosmos.Deploy.USB/packages.lock.json
+++ b/source/Cosmos.Deploy.USB/packages.lock.json
@@ -37,7 +37,7 @@
         }
       }
     },
-    "net6.0-windows7.0/win-x86": {
+    "net6.0-windows7.0/win-x64": {
       "Microsoft.Win32.Registry": {
         "type": "Transitive",
         "resolved": "5.0.0",

--- a/source/Cosmos.VS.DebugEngine/Cosmos.VS.DebugEngine.csproj
+++ b/source/Cosmos.VS.DebugEngine/Cosmos.VS.DebugEngine.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/source/Cosmos.VS.DebugEngine/packages.lock.json
+++ b/source/Cosmos.VS.DebugEngine/packages.lock.json
@@ -1330,7 +1330,7 @@
         }
       }
     },
-    ".NETFramework,Version=v4.8/win-x86": {
+    ".NETFramework,Version=v4.8/win-x64": {
       "Microsoft.Win32.Registry": {
         "type": "Direct",
         "requested": "[5.0.0, )",

--- a/source/Cosmos.VS.ProjectSystem/Cosmos.VS.ProjectSystem.csproj
+++ b/source/Cosmos.VS.ProjectSystem/Cosmos.VS.ProjectSystem.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <RootNamespace>Cosmos.VS.ProjectSystem</RootNamespace>
         <FileVersion>1.0.0.0</FileVersion>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/source/Cosmos.VS.ProjectSystem/packages.lock.json
+++ b/source/Cosmos.VS.ProjectSystem/packages.lock.json
@@ -1347,7 +1347,7 @@
         }
       }
     },
-    ".NETFramework,Version=v4.8/win-x86": {
+    ".NETFramework,Version=v4.8/win-x64": {
       "Microsoft.Win32.Registry": {
         "type": "Direct",
         "requested": "[5.0.0, )",

--- a/source/Cosmos.VS.Windows/Cosmos.VS.Windows.csproj
+++ b/source/Cosmos.VS.Windows/Cosmos.VS.Windows.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
-        <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
         <RootNamespace>Cosmos.VS.Windows</RootNamespace>
         <CreateVsixContainer>False</CreateVsixContainer>
         <DeployExtension>False</DeployExtension>

--- a/source/Cosmos.VS.Windows/packages.lock.json
+++ b/source/Cosmos.VS.Windows/packages.lock.json
@@ -1136,7 +1136,7 @@
         }
       }
     },
-    ".NETFramework,Version=v4.8/win-x86": {
+    ".NETFramework,Version=v4.8/win-x64": {
       "Microsoft.Win32.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",


### PR DESCRIPTION
Statement copied from cosmos dev-general:
An error appeared in latest cosmos with latest visual studio update and i point my figures back to a commit which involved changing many win-x64 to win-x86 causing president problems, the thread is here ⁠[...] changes to fix this bug include;
`
Build.Sln\
source/Cosmos.Deploy.Pixie/Cosmos.Deploy.Pixie.csproj - revert win-x86 back to win-x64 inside of RuntimeIdentifier
source/Cosmos.Deploy.USB/Cosmos.Deploy.USB.csproj - revert win-x86 back to win-x64 inside of RuntimeIdentifier
source/Cosmos.VS.DebugEngine/Cosmos.VS.DebugEngine.csproj - revert win-x86 back to win-x64 inside of RuntimeIdentifier
source/Cosmos.VS.ProjectSystem/Cosmos.VS.ProjectSystem.csproj - revert win-x86 back to win-x64 inside of RuntimeIdentifier
source/Cosmos.VS.Windows/Cosmos.VS.Windows.csproj - revert win-x86 back to win-x64 inside of RuntimeIdentifier
---------------------
Problem commit id: 95a6434dc1debff35139215208918525c09fdb77
`
which was done below, now cosmos builds on Latest visual studio & latest Cosmos