### PR TITLE
Cosmos Linux Fix

### DIFF
--- a/source/templates/csharp/CSharpProject.csproj
+++ b/source/templates/csharp/CSharpProject.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <DebugEnabled>false</DebugEnabled>
         <EnableGDB>False</EnableGDB>
         <StartCosmosGDB>False</StartCosmosGDB>
         <VisualStudioDebugPort>Pipe: Cosmos\Serial</VisualStudioDebugPort>


### PR DESCRIPTION
To be short, this debug enabled thing will allow new projects to have debug screens disabled, which is actually helpful because on linux you have to do it manually before dotnet build to get the project to actually run so it will be really nice if this was pre-included!