### PR TITLE
Fix ISO9660 support

### DIFF
--- a/source/Cosmos.Build.Tasks/MakeIso.cs
+++ b/source/Cosmos.Build.Tasks/MakeIso.cs
@@ -65,6 +65,7 @@ namespace Cosmos.Build.Tasks
             xBuilder.AppendSwitch("-J");
             xBuilder.AppendSwitch("-R");
             xBuilder.AppendSwitch("-l");
+            xBuilder.AppendSwitch("-allow-lowercase");
             xBuilder.AppendSwitchIfNotNull("-o ", OutputFile);
             xBuilder.AppendSwitch(" -b boot/limine-bios-cd.bin");
             xBuilder.AppendSwitch("-no-emul-boot");

--- a/source/Cosmos.HAL2/BlockDevice/ATAPI.cs
+++ b/source/Cosmos.HAL2/BlockDevice/ATAPI.cs
@@ -107,7 +107,7 @@ namespace Cosmos.HAL.BlockDevice
                 throw new NotImplementedException("Reading more than one sectors is not supported. SectorCount: " + SectorCount);
             }
 
-            ataDebugger.Send("ATAPI: Reading block. Sector: " + SectorNum + " SectorCount: " + SectorCount);
+            ataDebugger.SendInternal("ATAPI: Reading block. Sector: " + SectorNum + " SectorCount: " + SectorCount);
 
 
             byte[] packet = new byte[12];
@@ -182,10 +182,10 @@ namespace Cosmos.HAL.BlockDevice
 
             //Send ATAPI packet command
             device.SendCmd(Cmd.Packet);
-            ataDebugger.Send("ATAPI: Polling");
+            ataDebugger.SendInternal("ATAPI: Polling");
 
             Poll(true);
-            ataDebugger.Send("ATAPI: Polling complete");
+            ataDebugger.SendInternal("ATAPI: Polling complete");
 
             //Send the command as words
             for (int i = 0; i < AtapiPacket.Length; i++)

--- a/source/Cosmos.System2/FileSystem/ManagedPartition.cs
+++ b/source/Cosmos.System2/FileSystem/ManagedPartition.cs
@@ -21,9 +21,11 @@ namespace Cosmos.System.FileSystem
         /// </summary>
         public bool HasFileSystem => MountedFS != null;
 
-        public ManagedPartition(Partition host)
-        {
+        public string LimitFS = null;
+
+        public ManagedPartition(Partition host, string limitFS = null) {
             Host = host;
+            LimitFS = limitFS;
         }
 
         /// <summary>


### PR DESCRIPTION
- ISO9660 somehow got detected as FAT FS since UEFI support was added
- There is no block count on ATAPI devices (? not sure why that is), instead we just put a large number there. Its read only anyways.
- Xorriso somehow changed and output all file names as UPPERCASE. Adding -allow-lowercase made it go back to what it did before.