### PR TITLE
Revert Misha's commit for GCImpl

### DIFF
--- a/source/Cosmos.Core/GCImplementation.cs
+++ b/source/Cosmos.Core/GCImplementation.cs
@@ -84,6 +84,13 @@ namespace Cosmos.Core
             {
                 memPtr = (byte*)largestBlock->Address;
                 memLength = largestBlock->Length;
+                if ((uint)memPtr < CPU.GetEndOfKernel() + 1024)
+                {
+                    memPtr = (byte*)CPU.GetEndOfKernel() + 1024;
+                    memPtr += RAT.PageSize - (uint)memPtr % RAT.PageSize;
+                    memLength = largestBlock->Length - ((uint)memPtr - (uint)largestBlock->Address);
+                    memLength += RAT.PageSize - memLength % RAT.PageSize;
+                }
             }
             else
             {


### PR DESCRIPTION
The commit made by Misha 2 weeks ago broke the 'Cosmos.Core.Memory.Heap.Collect()' function. This commit aims to revert these changes