### PR TITLE
Updates on int.ToString(`format`)

### DIFF
--- a/Tests/Kernels/Cosmos.Compiler.Tests.Bcl.System/System/Int32Test.cs
+++ b/Tests/Kernels/Cosmos.Compiler.Tests.Bcl.System/System/Int32Test.cs
@@ -10,7 +10,7 @@ namespace Cosmos.Compiler.Tests.Bcl.System
         public static void Execute()
         {
             bool efuse;
-            int value, tmp;
+            int value;
             string result;
             string expectedResult;
 
@@ -47,24 +47,13 @@ namespace Cosmos.Compiler.Tests.Bcl.System
             // Ensure value is not overrided
             Assert.IsTrue((value != 0), "Int32.ToString(X) overrides the value of the variable.");
 
-            tmp = value;
-            result = ToStringOld(ref tmp, "X");
+            // Hex with padding
+            value = 255;
+            result = value.ToString("X4");
+            expectedResult = "00FF";
+            Assert.IsTrue((result == expectedResult), "Int32.ToString(X4) brings incorrect result.");
 
-            // This is just to demostrates that the changed version bring correct results
-            Assert.IsTrue((result == expectedResult), "Int32.ToString(X) brings incorrect result");
-
-            // Demostrate how old version overrided the the variable value.
-            Assert.IsTrue((tmp == 0), "ToStringOld(X), did not override");
-
-            // Test results with another implementation of hex format
-            foreach (int i in Enumerable.Range(0,256))
-            {
-                result = i.ToString("X4");
-                expectedResult = i.ToHex(4);
-                Assert.IsTrue((result == expectedResult), "Int32.ToString(X) brings incorrect result.");
-            }
-
-            // Test Decimal format
+            // Test Decimal format wit padding
             value = 10;
             expectedResult = "0010";
             result = value.ToString("D4");

--- a/Tests/Kernels/Cosmos.Compiler.Tests.Bcl.System/System/Int32Test.cs
+++ b/Tests/Kernels/Cosmos.Compiler.Tests.Bcl.System/System/Int32Test.cs
@@ -249,51 +249,5 @@ namespace Cosmos.Compiler.Tests.Bcl.System
         {
             aParam++;
         }
-
-        // Original int32.ToString(format)
-        private static string ToStringOld(ref int aThis, string format)
-        {
-            if (format.Equals("X"))
-            {
-                string result = "";
-
-                if (aThis == 0)
-                {
-                    result = "0";
-                }
-
-                while (aThis != 0)
-                {
-                    if (aThis % 16 < 10)
-                    {
-                        result = aThis % 16 + result;
-                    }
-                    else
-                    {
-                        string temp = "";
-
-                        switch (aThis % 16)
-                        {
-                            case 10: temp = "A"; break;
-                            case 11: temp = "B"; break;
-                            case 12: temp = "C"; break;
-                            case 13: temp = "D"; break;
-                            case 14: temp = "E"; break;
-                            case 15: temp = "F"; break;
-                        }
-
-                        result = temp + result;
-                    }
-
-                    aThis /= 16;
-                }
-
-                return result;
-            }
-            else
-            {
-                return aThis.ToString();
-            }
-        }
     }
 }

--- a/source/Cosmos.System2_Plugs/System/Int32Impl.cs
+++ b/source/Cosmos.System2_Plugs/System/Int32Impl.cs
@@ -13,46 +13,48 @@ namespace Cosmos.System_Plugs.System
 
         public static string ToString(ref int aThis, string format)
         {
-            if (format.Equals("X"))
+            if (string.IsNullOrEmpty(format))
             {
-                string result = "";
+                return "0";
+            }
 
-                if(aThis == 0)
-                {
-                    result = "0";
-                }
+            string result = aThis > 0 ? string.Empty : "0";
 
-                while (aThis != 0)
-                {
-                    if (aThis % 16 < 10)
+            switch (format[0])
+            {
+                case 'X':
+                    int value = aThis;
+
+                    while (value != 0)
                     {
-                        result = aThis % 16 + result;
-                    }
-                    else
-                    {
-                        string temp = "";
-
-                        switch (aThis % 16)
+                        int remainder = value % 16;
+                        if (remainder < 10)
                         {
-                            case 10: temp = "A"; break;
-                            case 11: temp = "B"; break;
-                            case 12: temp = "C"; break;
-                            case 13: temp = "D"; break;
-                            case 14: temp = "E"; break;
-                            case 15: temp = "F"; break;
+                            result = remainder + result;
+                        }
+                        else
+                        {
+                            char temp = (char)('A' + (remainder - 10));
+                            result = temp + result;
                         }
 
-                        result = temp + result;
+                        value /= 16;
                     }
+                    break;
+                case 'D':
+                    result = aThis.ToString();
+                    break;
+                default:
+                    return aThis.ToString();
+            }
 
-                    aThis /= 16;
-                }
-
-                return result;
+            if (format.Length > 1)
+            {
+                return int.TryParse(format.AsSpan(1), out int number) ? result.PadLeft(number, '0') : aThis.ToString();
             }
             else
             {
-                return aThis.ToString();
+                return result;
             }
         }
 

--- a/source/Cosmos.System2_Plugs/System/Int32Impl.cs
+++ b/source/Cosmos.System2_Plugs/System/Int32Impl.cs
@@ -18,7 +18,7 @@ namespace Cosmos.System_Plugs.System
                 return "0";
             }
 
-            string result = aThis > 0 ? string.Empty : "0";
+            string result = aThis == 0 ? "0" : string.Empty;
 
             switch (format[0])
             {

--- a/source/Cosmos.System2_Plugs/System/Int32Impl.cs
+++ b/source/Cosmos.System2_Plugs/System/Int32Impl.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Cosmos.Common;
 using IL2CPU.API.Attribs;
 
@@ -18,11 +19,17 @@ namespace Cosmos.System_Plugs.System
                 return "0";
             }
 
-            string result = aThis == 0 ? "0" : string.Empty;
+            StringBuilder sb = new();
 
             switch (format[0])
             {
                 case 'X':
+                    if (aThis == 0)
+                    {
+                        sb.Append('0');
+                        break;
+                    }
+
                     int value = aThis;
 
                     while (value != 0)
@@ -30,23 +37,25 @@ namespace Cosmos.System_Plugs.System
                         int remainder = value % 16;
                         if (remainder < 10)
                         {
-                            result = remainder + result;
+                            sb.Insert(0, remainder);
                         }
                         else
                         {
                             char temp = (char)('A' + (remainder - 10));
-                            result = temp + result;
+                            sb.Insert(0, temp);
                         }
 
                         value /= 16;
                     }
                     break;
                 case 'D':
-                    result = aThis.ToString();
+                    sb.Append(aThis);
                     break;
                 default:
                     return aThis.ToString();
             }
+
+            var result = sb.ToString();
 
             if (format.Length > 1)
             {


### PR DESCRIPTION
Improved Hexadecimal format code as it was changing the value of the original variable (tested only on [SharpLab](https://sharplab.io/), since I did the change before testing on Cosmos, but I assume that if it was changing on normal C# context, then it should have been changing on Cosmos too), also added support for the decimal format and padding.