### PR TITLE
Remove FS warnings from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,12 @@ In a project, Cosmos can be thought of as a compiler and a sort-of standard libr
 The following is a non-exhaustive list of features that Cosmos offers:
 
 - Low level assembly access and pointer memory control
-- A basic (and unstable at the moment) filesystem
+- A basic filesystem
 - Most features found in the .NET core library
 - A CPU/FPU accelerated math library
 - A basic graphics interface
 - A basic network interface
 - A basic audio interface
-
-> [!NOTE]
-> Use [embeded resources](https://cosmosos.github.io/articles/Kernel/ManifestResouceStream.html) instead of the VFS for now for assets.
 
 ## Setting it up
 


### PR DESCRIPTION
With the recent changes the FS is a pretty stable and decently fast, so imo these notes should be removed.