### PR TITLE
Adjust COSMOS documentation

### DIFF
--- a/Docs/articles/Changelog.md
+++ b/Docs/articles/Changelog.md
@@ -10,3 +10,5 @@
 ### Breaking changes
 
 Plugs are now included via a nuget package, to update cosmos past this commit you need to add the `Cosmos.Plugs` package to your kernel project. Don't forget to tick the `Include prerelease` checkbox and to set the package origin to `All`!
+
+*Last updated on 4 September 2023.*

--- a/Docs/articles/Changelog.md
+++ b/Docs/articles/Changelog.md
@@ -1,4 +1,4 @@
-# Devkit changelog
+# DevKit changelog
 
 ## c5c087c697d106348adbcff86d5d43331500e648 (update then merged in)
 

--- a/Docs/articles/Compiler/il2cpu.md
+++ b/Docs/articles/Compiler/il2cpu.md
@@ -1,13 +1,13 @@
 # IL2CPU
 
-This is one of the most important pieces of code in Cosmos. It's an AOT (Ahead-Of-Time) compiler.
+IL2CPU is one of the most important pieces of code in Cosmos. It's an AOT (Ahead-Of-Time) compiler.
 
-When you compile your C# (or any .NET language) program, it is compiled into CIL (common intermediate language). The CIL is then interpreted and executed by a virtual machine when you open your exe.
+When you compile your C# (or any other .NET language) program, it is compiled into CIL (common intermediate language). The CIL is then interpreted and executed by a virtual machine when you open your .exe.
 
-Cosmos is written in C# and Visual Studio compiles it into CIL as always. But a PC does not come with an interpreter for the CIL code. And writing a virtual machine for running an operating system is not always ideal.
+Cosmos is written in C# and Visual Studio compiles it into CIL like usual. But a PC does not come with an interpreter for the CIL code, and writing a virtual machine for running an operating system is not ideal.
 
-This is where IL2CPU comes in. IL2CPU takes the CIL code and translates it to processor opcodes. Currently, only x86 opcodes are available at the moment. However, more architectures are planned for the future (ARM, PowerPC, x86-64).
+This is where IL2CPU comes in. IL2CPU takes the CIL code and translates it to processor op-codes. Currently, only x86 opcodes are available at the moment. However, more architectures are planned for the future (ARM, PowerPC, x86-64).
 
-At this point, IL2CPU performs some more magic before finally converting the entire file into a bootable binary file, which can be loaded by a bootloader on any system (Cosmos uses the [Limine bootloader](https://github.com/limine-bootloader/limine)).
+At this point, IL2CPU performs some more magic before finally converting the entire file into a bootable binary file, which can be loaded by a bootloader on any system (Cosmos uses the [Limine bootloader](https://github.com/limine-bootloader/limine).
 
 As you might think, IL2CPU is a fundamental part of the development of Cosmos. IL2CPU is responsible for the final output, which is why most optimizations added are for IL2CPU.

--- a/Docs/articles/Compiler/il2cpu.md
+++ b/Docs/articles/Compiler/il2cpu.md
@@ -11,3 +11,5 @@ This is where IL2CPU comes in. IL2CPU takes the CIL code and translates it to pr
 At this point, IL2CPU performs some more magic before finally converting the entire file into a bootable binary file, which can be loaded by a bootloader on any system (Cosmos uses the [Limine bootloader](https://github.com/limine-bootloader/limine).
 
 As you might think, IL2CPU is a fundamental part of the development of Cosmos. IL2CPU is responsible for the final output, which is why most optimizations added are for IL2CPU.
+
+*Last updated on 24 March 2024.*

--- a/Docs/articles/Debugger/DebugCommands.md
+++ b/Docs/articles/Debugger/DebugCommands.md
@@ -60,3 +60,5 @@ Max = 18;
 
 ## Debug channel
 We support channels, which are prefixed with anything prefixed with 192 and up. 192 is used for a debug view.
+
+*Last updated on 12 February 2020.*

--- a/Docs/articles/GettingStarted.md
+++ b/Docs/articles/GettingStarted.md
@@ -127,3 +127,4 @@ the mainline Cosmos development as of yet.
   * Cosmos website - [http://www.GoCosmos.org](http://www.GoCosmos.org)
   * Source code - Both DevKit and User Kit - [http://github.com/CosmosOS/Cosmos/](http://github.com/CosmosOS/Cosmos/)
 
+*Last updated on 24 March 2024.*

--- a/Docs/articles/GettingStarted.md
+++ b/Docs/articles/GettingStarted.md
@@ -4,27 +4,20 @@
 
 Cosmos (C# Open Source Managed Operating System) is an operating system
 development kit which uses Visual Studio as its development environment.
-Despite C# in the name any .NET based language can be used including VB.NET,
+Despite C# in the name, any .NET based language can be used, including VB.NET,
 Fortran, Delphi Prism, IronPython, F# and more. Cosmos itself and the kernel
 routines are primarily written in C#, and thus the Cosmos name. Besides that,
-NOSMOS (.NET Open Source Managed Operating System) sounds stupid.
+NOSMOS (.NET Open Source Managed Operating System) sounds silly.
 
-Cosmos is not an operating system in the traditional sense, but instead it is
-an "Operating System Kit", or as I like to say "Operating System Legos".
-Cosmos lets you create operating systems just as Visual Studio and C# normally
-let you create applications. Most users can write and boot their own operating
-system in just a few minutes, all using Visual Studio. You can debug your operating system directly from Visual
-Studio using breakpoints.
+Cosmos diverts from traditional operating systems because it is not an operating system in the conventional sense; rather, it is an "Operating System Kit," similar to "Operating System Legos". With Cosmos, you have the flexibility to construct operating systems just as how Visual Studio and C# help you develop applications. Using Visual Studio, most users can swiftly write and boot their own operating system within minutes. Additionally, debugging your operating system directly from Visual Studio is a feature, allowing for efficient troubleshooting through breakpoints.
 
-Cosmos is available in two distributions, the developer kit (dev kit), and the user kit. The dev kit is designed for users who want to work on Cosmos itself.
-The user kit is designed for those who are interested in building their own
-operating system and doing some Cosmos work. The dev kit might be thought of
-as the Cosmos SDK. Most users should start off with the user kit as it is not
-so overwhelming like the dev kit. This article focuses on the user kit.
+Cosmos is available in two distributions, the developer kit (abbr. *DevKit*), and the user kit. 
+The DevKit was originally designed for those who want to work on Cosmos's core features, but now has superceded the inferior user kit due to having much more technical ability.
+The User Kit was designed for those who are interested in building their own operating system and doing some Cosmos work. Since the User Kit is so heavily outdated, it is often recommended to download the DevKit when installing. The documentation will cover both.
 
 ##  Writing your first Operating System
 
-Create a new project as you would any C# project, but select Cosmos as the project type.
+Once you have installed Cosmos (see other docs), you can create a new project as you would any C# project, but select Cosmos as the project type.
 
 ![](images/SNAG-0000.png)
 
@@ -39,8 +32,8 @@ console window, you will see the following:
 ![](images/SNAG-0003.png)
 
 This is your operating system running in VMware Player! Cosmos can of course
-also be booted in VMware Workstation, Hyper-V, Virtual PC, Bochs, or on real
-hardware. But by default Cosmos uses VMware Player because it is both free,
+also be booted in VMware Workstation, VirtualBox, Bochs, or on real
+hardware. But by default, Cosmos uses VMware Player because it is both free,
 and reliable. Cosmos can even debug in Visual Studio, even when running on
 another machine.
 
@@ -48,10 +41,10 @@ another machine.
 
 Debugging is a major issue with operating system development. The Cosmos team
 was not content enough to simply conquer building and deployment, we want to
-make developing operating system as easy as developing Windows applications.
+make developing operating systems as easy as developing Windows applications.
 Debugging a Cosmos based operating system should feel very familiar to you.
 Lets modify our project a little bit to show the effect, and set a breakpoint. 
-**Note that the debugger only works in Visual Studio, and not Linux**
+*Note that the debugger only works in Visual Studio, and not Linux!*
 
 ![](images/SNAG-0005.png)
 
@@ -59,20 +52,20 @@ Now run the project again.
 
 ![](images/SNAG-0007.png)
 
-Note that the execution stopped at "One"? That is becuase in Visual Studio our
+Notice how the execution stopped at "One"? That is becuase in Visual Studio our
 project has stopped on a breakpoint. Simply press F5 to continue just as you
 would in a normal application!
 
-In addition to breakpoints Cosmos also supports step into (F11) as well. Trace
+In addition to breakpoints, Cosmos also supports step into (F11) as well. Trace
 over (F10) is not supported yet.
 
 ##  Debugger Communication
 
 The debugger uses the serial port to communicate. Because of this, debugging
-only works wtih virtualization environments that support serial ports such as
+only works within virtualization environments that support serial ports, such as
 VMware. QEMU supports serial ports as well, but its serial port implementation
 is seriously broken on Windows and makes debugging impossible using QEMU. To
-debug on real hardware, you must use a physical serial cable. In the future
+debug on real hardware, you must use a physical serial cable. In the future,
 Cosmos will also support debugging over Ethernet.
 
 ##  Extra Debugging
@@ -109,7 +102,7 @@ Both functions will produce the same result.
 
 ##  Debug Output
 
-Debug strings can be output to the debug window of the host. Because Cosmos
+Debug strings can be outputted to the debug window of the host. Because Cosmos
 does not support watches yet, this functionality can be very useful for
 watching variable values and for performing tracing without breakpoints.
 
@@ -124,13 +117,13 @@ and it will appear in the Visual Studio output window.
 ##  What's the catch?
 
 There really is no catch. Everything we've shown here is functioning as seen.
-No mockups were used. However we still have a lot of work to go. Items of
-interest that are on our current task list include threads and networking. 
+No mockups were used. However, we still have a lot of work to do. Items of
+interest that are on our current task list include multithreading and x64 systems. 
 We have prototypes and experiments for each, but none have been rolled into 
 the mainline Cosmos development as of yet.
 
 ##  Obtaining Cosmos
 
-  * Cosmos Website - [http://www.GoCosmos.org](http://www.GoCosmos.org)
-  * Source Code - Both dev kit and user kit - [http://github.com/CosmosOS/Cosmos/](http://github.com/CosmosOS/Cosmos/)
+  * Cosmos website - [http://www.GoCosmos.org](http://www.GoCosmos.org)
+  * Source code - Both DevKit and User Kit - [http://github.com/CosmosOS/Cosmos/](http://github.com/CosmosOS/Cosmos/)
 

--- a/Docs/articles/Installation/DevKit.md
+++ b/Docs/articles/Installation/DevKit.md
@@ -1,18 +1,19 @@
-# Dev Kit Installation 
+# DevKit Installation 
 
 ## Windows
 
 ###  Prerequisites
 
-* (Free) source code of Development Kit from [Cosmos on GitHub](https://github.com/CosmosOS/Cosmos)
+* Source code of Development Kit from [Cosmos on GitHub](https://github.com/CosmosOS/Cosmos)
    * You must clone the repository using Git. For a detailed walkthrough, [see here](https://help.github.com/articles/fork-a-repo/).
-* (Free) [Visual Studio 2022 Community](https://visualstudio.microsoft.com/vs/)  
-* (Free) [InnoSetup](http://www.jrsoftware.org/isdl.php#qsp)
+* [Visual Studio 2022 Community](https://visualstudio.microsoft.com/vs/)  
+* [InnoSetup](http://www.jrsoftware.org/isdl.php#qsp)
    * This is required to build the setup kit which is used to build and install the Visual Studio integration libaries for Cosmos.
    * During install it will ask you about optional components to install. Be sure you check "Install Inno Setup Preprocessor".
 
 ###  Installation
 
+* Git clone the current source code of Cosmos and rename the folder to simply 'Cosmos'.
 * Look in the downloaded sources and run **install-VS2022.bat** with admin privileges (UAC will ask for permission), needed for install in system directories.
 * When the installation is complete, Visual Studio will automatically open and you may begin programming with your new, modified copy of Cosmos.
 
@@ -28,49 +29,49 @@
 * QEMU or any other virtual machine. See [Running](https://cosmosos.github.io/articles/Installation/Running.html) for more information.
 
 ###  Installation
-Run `make` to build Cosmos. Cosmos will clone all the required repos, build itself, and install it and it's nuget packages to the system automatically.
+Git cline the current source code of Cosmos.
+Run `make` to build Cosmos. Cosmos will clone all the required repos, build itself, and install it and its nuget packages to the system automatically.
 
 ## MacOS (Apple Silicon/Intel)
-There is currently hard to build on Apple Silicon Devices. So are going to build DevKit on Docker (Virtual Environment Service).
+It is currently difficult to build Cosmos on Apple Silicon Devices. So, we are going to build DevKit on Docker (Virtual Environment Service).
 
 ### Prerequisites
 
-* Docker(`brew cask install docker`)
+* Docker (`brew cask install docker`)
 * QEMU or any other virtual machine. See [Running](https://cosmosos.github.io/articles/Installation/Running.html) for more information.
 
 
 ###  Installation
-First we need to set directory to the path of Cosmos source directory and build the Dockerfile:
+First, we need to set directory to the path of Cosmos source directory and build the Dockerfile:
 ```
 cd /path/to/Cosmos/
 docker build -t cosmos .
 ```
 This will take a while. If there is no error, you successfully installed Cosmos on a Virtual Environment!
 
-## notes / FAQ
+## Notes / FAQ
 
-### custom cosmos repos
+### Custom Cosmos Repos
 
-if you are using custom cosmos repos you will need to clone them all manually as the installer script will pull from https://github.com/CosmosOS/
+If you are using custom Cosmos repos, you will need to clone them all manually, as the installer script will only pull from https://github.com/CosmosOS/
 
 A tree diagram of the source should look like the following:   
 
 <img src="https://raw.githubusercontent.com/CosmosOS/Cosmos/master/Docs/images/Dir.png" width="200">
 
 
-### get stuck pulling the git repos
+### I get stuck pulling the git repos!
 
-check if git is installed and in your path as we use git to pull the repos
+Check if [Git](https://git-scm.com/) is installed on your machine and within your path. We use Git to pull the repos from GitHub.
 
-### i just updated and my project is sill using the old version
+### I just updated my DevKit and my project is still using the older version!
 
-you may need to clear you nuget cache try ``dotnet clean`` to clear the project level cache
+Although Cosmos typically uninstalls previous kits before installing a new one; it is possible that your project can reference an older-version. In the rare case this does occur, you may need to clear the NuGet cache. Try running `dotnet clean` to clear the project-level cache. 
 
-### the project templates are not showing in visual studio
+### The project templates are not showing in Visual Studio!
 
-if you have more then 1 version of visual studio installed this can bug this follow "dotnet Project Templates" should fix it
+If you have more than 1 version of Visual Studio *(such as both 2022 and 2019)*, this bug can occur. Try running `dotnet Project Templates` to get them back.
 
 ### dotnet Project Templates
-If you are using linux or prefer not using Visual Studio for your projects, you can install the dotnet project template using `dotnet new --install ./source/templates/csharp/` assuming you are currently in the Cosmos base directory.
-After installing the template use `dotnet new cosmosCSKernel -n {name}` to create a new Cosmos Kernel project. 
+If you are using Linux, or prefer not using Visual Studio for your projects, you can install the dotnet project template using `dotnet new --install ./source/templates/csharp/` assuming you are currently in the Cosmos base directory. After installing the template, use `dotnet new cosmosCSKernel -n {name}` to create a new Cosmos Kernel project. 
 The dotnet template can be removed at a later time using `dotnet new --uninstall ./source/templates/csharp/`.

--- a/Docs/articles/Installation/DevKit.md
+++ b/Docs/articles/Installation/DevKit.md
@@ -13,7 +13,7 @@
 
 ###  Installation
 
-* Git clone the current source code of Cosmos and rename the folder to simply 'Cosmos'.
+* Git clone the current source code of Cosmos or download the source code directly from GitHub. If you downlaod the source code, you will need to rename the folder to simply 'Cosmos'.
 * Look in the downloaded sources and run **install-VS2022.bat** with admin privileges (UAC will ask for permission), needed for install in system directories.
 * When the installation is complete, Visual Studio will automatically open and you may begin programming with your new, modified copy of Cosmos.
 
@@ -75,3 +75,5 @@ If you have more than 1 version of Visual Studio *(such as both 2022 and 2019)*,
 ### dotnet Project Templates
 If you are using Linux, or prefer not using Visual Studio for your projects, you can install the dotnet project template using `dotnet new --install ./source/templates/csharp/` assuming you are currently in the Cosmos base directory. After installing the template, use `dotnet new cosmosCSKernel -n {name}` to create a new Cosmos Kernel project. 
 The dotnet template can be removed at a later time using `dotnet new --uninstall ./source/templates/csharp/`.
+
+*Last updated on 24 March 2024.*

--- a/Docs/articles/Installation/Running.md
+++ b/Docs/articles/Installation/Running.md
@@ -62,6 +62,7 @@ qemu-system-x86_64 -boot d -cdrom $ISO -m $MEMORY_SIZE -hda $HDD_IMAGE
 
 ## VirtualBox
 Create a virtual machine and use this [.vmdk](https://github.com/CosmosOS/Cosmos/blob/master/Build/VMWare/Workstation/Filesystem.vmdk?raw=true) as your HDD image.
+If you are utilizing audio, we recommend VirtualBox for the ability to use their AC97 driver.
 
 # Windows
 
@@ -85,12 +86,13 @@ VMWare Workstation (paid version) can be downloaded for a free trial [here](http
 ##  QEMU
 
 QEMU is not officially supported for Cosmos at this time, but can be used. Just use the ISO option above with debugging turned off.
+If you want to use graphical mode in QEMU (Canvas or SVGA-II), ensure that VBE multiboot is enabled in your project settings of Cosmos.
 
 QEMU can be downloaded [here](https://www.qemu.org/download/)
 
 ## Bochs
 
-Bochs is officially supported for Cosmos.
+Bochs is officially supported for Cosmos. As Bochs is a full emulation software, results vary and are often times slower than other virtualization platforms.
 
 Bochs can be downloaded [here](https://bochs.sourceforge.io/getcurrent.html)
 
@@ -115,3 +117,4 @@ Wait and your OS will boot up.
 Not supported at this time.
 
 
+*Last updated on 24 March 2024.*

--- a/Docs/articles/Installation/Running.md
+++ b/Docs/articles/Installation/Running.md
@@ -1,8 +1,8 @@
 # Running
-Cosmos supports running on any Intel x86 environment. However for debugging
+Cosmos supports running on any Intel x86 environment. However, for debugging
 and ease of use, many virtual and physical setups have integrated support. If
 you do not see your environment, this does not mean Cosmos will not work. You
-can simply fall back to ISO which should work with any environment.
+can simply fall back to ISO, which should work with any environment.
 
 ##  ISO
 
@@ -11,17 +11,17 @@ mounted and booted by most virtualization technologies. In addition, a physical
 optical disk can be burned and used to boot physical hardware.
 
 # Linux/Posix
-### DISCLAIMER: This article assumes that you are using a debian based operating system
+**DISCLAIMER: This article assumes that you are using a Debian-based operating system!**
 
 ## QEMU
-Here you can use a generic run file, you can run it by using `sh run.sh -i <ISO> -m <memory size> -h <hdd image>`.
-It has to be at the root directory of the project
+Here you can use a generic run file, you can run it by using `sh run.sh -i <ISO> -m <memory size> -h <hdd image>`. It has to be at the root directory of the project.
 
 QEMU is required and can be installed with `apt-get install qemu-system`.
 
-To create an hdd image, you have to convert this [.vmdk](https://github.com/CosmosOS/Cosmos/blob/master/Build/VMWare/Workstation/Filesystem.vmdk?raw=true) file to a .img wich can then be used by QEMU using the following command
+To create an HDD image, you have to convert this [.vmdk](https://github.com/CosmosOS/Cosmos/blob/master/Build/VMWare/Workstation/Filesystem.vmdk?raw=true) file to a .img, which can then be used by QEMU using the following command
 `qemu-img convert -f vmdk -O raw Filesystem.vmdk cosmos.img`
 
+Here is the run.sh:
 `run.sh:`
 ```sh
 #!/bin/bash
@@ -60,8 +60,8 @@ dotnet build
 qemu-system-x86_64 -boot d -cdrom $ISO -m $MEMORY_SIZE -hda $HDD_IMAGE
 ```
 
-## Virtualbox
-Create a virtual machine and use this [.vmdk](https://github.com/CosmosOS/Cosmos/blob/master/Build/VMWare/Workstation/Filesystem.vmdk?raw=true) as HDD image
+## VirtualBox
+Create a virtual machine and use this [.vmdk](https://github.com/CosmosOS/Cosmos/blob/master/Build/VMWare/Workstation/Filesystem.vmdk?raw=true) as your HDD image.
 
 # Windows
 
@@ -80,17 +80,17 @@ VMWare Player can be downloaded [here](https://www.vmware.com/go/getplayer-win).
 
 ### VMWare Workstation
 
-VMWare Workstation can be downloaded for free trial [here](https://www.vmware.com/go/getworkstation-win).
+VMWare Workstation (paid version) can be downloaded for a free trial [here](https://www.vmware.com/go/getworkstation-win).
 
 ##  QEMU
 
-Not officially supported at this time, but can be done. Just use the ISO option above with debugging turned off.
+QEMU is not officially supported for Cosmos at this time, but can be used. Just use the ISO option above with debugging turned off.
 
 QEMU can be downloaded [here](https://www.qemu.org/download/)
 
 ## Bochs
 
-Bochs is officially supported.
+Bochs is officially supported for Cosmos.
 
 Bochs can be downloaded [here](https://bochs.sourceforge.io/getcurrent.html)
 
@@ -99,7 +99,7 @@ Bochs can be downloaded [here](https://bochs.sourceforge.io/getcurrent.html)
 For PXE, no special software is required. Only an ethernet connection to your router. However, if you have a computer that does not support network booting, or if you must perform the action over WiFi, you may need to look at a PXE chainloader such as [gPXE](http://etherboot.org/wiki/).
 To run your Cosmos kernel in PXE you need to follow these steps:
 
-Step #1: disable Cosmos Remote Debugger, activate PXE and compilation in bin format.
+Step #1: Disable Cosmos Remote Debugger, activate PXE and compile in bin format.
 Go to Properties and copy these settings:
 
 ![image](https://user-images.githubusercontent.com/98218366/178479237-a22a7b5f-250e-432d-ba74-0da502e82f7b.png)
@@ -108,9 +108,9 @@ Boot the machine and connect it via Ethernet and will show this screen:
 
 ![image](https://user-images.githubusercontent.com/98218366/178479800-c70faa5d-1fab-4da4-8f27-05eefee89b75.png)
 
-Wait and your os will boot up.
+Wait and your OS will boot up.
 
-## Hyper-V
+## Hyper-V, VirtualPC
 
 Not supported at this time.
 

--- a/Docs/articles/Installation/UserKit.md
+++ b/Docs/articles/Installation/UserKit.md
@@ -1,10 +1,9 @@
-# Installation
+# User Kit Installation
 
-for DevKit / linux see [DevKit](DevKit.md)
+for DevKit / running on Linux see [DevKit](DevKit.md)
 
 ### Prerequisites
   
-
 *   **Visual Studio 2022** - [Download](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx)
 *   **Visual Studio 2022 Workload: .NET Desktop** - .NET Desktop development
 *   **.NET 6.0** - [Download](https://www.microsoft.com/en-us/download/details.aspx?id=53321)
@@ -13,10 +12,9 @@ for DevKit / linux see [DevKit](DevKit.md)
   
 ### Installing Cosmos
  
-First, you need to choose between the User Kit and the Dev Kit. It is recommended that new users start with the User Kit but only move later to the Dev Kit if you need the latest features and want to contribute back to the main project. 
-The Dev Kit is the live source against which the Cosmos Team develops directly. The Dev Kit has the latest and greatest features, but at various times has known issues, and sometimes may not even build. Thus to use the Dev Kit be sure to join our support channels and inquire about the current status before using the Dev Kit or updating it. 
+First, you need to choose between the User Kit and the Dev Kit. It is recommended that any user start with the Dev Kit now due to the technical advancement of it - the User Kit is almost 2 years old in comparison! The DevKit is the live source code which the Cosmos Team develops directly, and as such, it has the latest and greatest features, but at various times has known issues, and sometimes may not even build. Thus, to use the DevKit, be sure to join our support channels and inquire about the current status before using the DevKit or updating it. 
   
-The User Kit is a snapshot stable version of Cosmos including a premade installer. The UserKit however is often quite a bit out of date compared to the DevKit and is only occasionally updated. The User Kit is a great easy way to get familiar with Cosmos, but active developers should transition to the Dev Kit after becoming very familiar with the UserKit, and expect some bugs here and there.
+The User Kit is a snapshot stable version of Cosmos including a premade installer. The UserKit however is often very out of date compared to the DevKit and is only occasionally updated. The User Kit is a great easy way to get familiar with Cosmos, but active developers should transition to the DevKit after becoming very familiar with the UserKit, and expect some bugs here and there.
   
 ### User Kit
   

--- a/Docs/articles/Installation/UserKit.md
+++ b/Docs/articles/Installation/UserKit.md
@@ -23,3 +23,5 @@ The User Kit is a snapshot stable version of Cosmos including a premade installe
 3.  Click "Next" then "Install"
 4.  Wait for the install to progress. **Tip:** At the end the installer may look like it has stalled, but it is still doing something in the background. WAIT for the "Finish" button to become available.
 5.  Cosmos should now be installed. Follow other tutorials to find out how to create your first OS.
+
+*Last updated on 24 March 2024.*

--- a/Docs/articles/Kernel/Audio.md
+++ b/Docs/articles/Kernel/Audio.md
@@ -16,7 +16,7 @@ var audioManager = new AudioManager()
 audioManager.Enable();
 ```
 
-The sampleAudioBytes are the bytes of a ttf audio file. You can read it from [VFS](https://cosmosos.github.io/articles/Kernel/VFS.html) or using [ManifestResourceStream](https://cosmosos.github.io/articles/Kernel/ManifestResouceStream.html)
+The sampleAudioBytes are the bytes of a .WAV audio file. You can read it from [VFS](https://cosmosos.github.io/articles/Kernel/VFS.html) or using [ManifestResourceStream](https://cosmosos.github.io/articles/Kernel/ManifestResouceStream.html).
 
 ## Audio Streams
 An `AudioStream` is an object that can provide sample data to audio buffers. By design, the base `AudioStream` class does not have any length or position properties, as audio streams may be infinite - for example, an output stream from a microphone, or an audio mixer. All seekable streams inherit from the class `SeekableAudioStream`, which provides functionality for accessing the position/length properties and allows methods to determine whether they accept infinite and finite streams, or only finite streams.

--- a/Docs/articles/Kernel/Audio.md
+++ b/Docs/articles/Kernel/Audio.md
@@ -81,3 +81,5 @@ The audio manager accepts a `Stream` and an `Output` property - the `Stream` is 
 
 > **Note**<br>
 - > When interfacing with audio devices, remember not to overload the system when supplying the audio samples. When mixing several streams of audio of different formats, for example, the system can get too overloaded, and this will result in audio crackle, or the system won't be able to respond to the audio device in time, resulting in the audio device stopping all output unexpectedly.
+
+*Last updated on 28 July 2023.*

--- a/Docs/articles/Kernel/CGS.md
+++ b/Docs/articles/Kernel/CGS.md
@@ -5,7 +5,7 @@ The Cosmos Graphic Subsystem *(abbr. CGS)* is based on the abstraction of Canvas
 # FullScreenCanvas
 The `FullScreenCanvas` provides two methods to get a canvas instance for the screen. It automatically chooses the best available driver to use.
 
-`public static Canvas GetFullScreenCanvas(Mode mode)`: gets the instance of Canvas representing the complete screen in the specified mode. The modes currently available are as follows:
+`public static Canvas GetFullScreenCanvas(Mode mode)`: gets the instance of Canvas representing the complete screen in the specified mode. Some modes that are currently available are as follows: *(depends on the backend used)*
 
 ```CSharp
 320x240, 32
@@ -147,3 +147,5 @@ If you use SVGAIICanvas, you can use 24 bit Color depth, and if you use VGACanva
 
 # Old examples 
 On the internet, there have been a lot of tutorials explaining how to use graphics in Cosmos, but most of them are outdated. Just remember that the new Mouse class is Sys.MouseManager and Pen has been replaced with Color.
+
+*Last updated on 28 July 2023.*

--- a/Docs/articles/Kernel/CGS.md
+++ b/Docs/articles/Kernel/CGS.md
@@ -1,20 +1,34 @@
 # Introduction
 
-The Cosmos Graphic Subsystem (CGS from now on) is based on the abstraction of Canvas that is an empty space in which the user of CGS can draw its content. CGS is not a widget toolkit as Winforms or Gnome / GTK but is thought to be more lower level and it will be the basic in which widget toolkits will be implemented. CGS hides the graphics driver (so far VGA, VBE and SVGAII) used and it is thought to be the universal way to draw on the screen in Cosmos.
+The Cosmos Graphic Subsystem *(abbr. CGS)* is based on the abstraction of Canvas that is an empty space in which the user of CGS can draw its content. CGS is not a widget toolkit like Winforms or Gnome / GTK, but is thought to be more lower level and is the basic foundation in which widget toolkits will be implemented. CGS hides the graphics driver (so far VGA, VBE and SVGAII) used and it is thought to be the universal way to draw on the screen in Cosmos.
 
 # FullScreenCanvas
 The `FullScreenCanvas` provides two methods to get a canvas instance for the screen. It automatically chooses the best available driver to use.
 
-`public static Canvas GetFullScreenCanvas(Mode mode)`: gets the instance of Canvas representing the complete screen in the specified mode
+`public static Canvas GetFullScreenCanvas(Mode mode)`: gets the instance of Canvas representing the complete screen in the specified mode. The modes currently available are as follows:
 
-`public static Canvas GetFullScreenCanvas()`: gets the instance of Canvas representing the complete screen in the best driver available on your platform
+```CSharp
+320x240, 32
+640x480, 32
+800x600, 32
+1024x768, 32
+1280x720, 32
+1280x768, 32
+1280x1024, 32
+1366x768, 32
+1680x1050, 32
+1920x1080, 32
+1920x1200, 32
+```
+
+`public static Canvas GetFullScreenCanvas()`: gets the instance of Canvas representing the complete screen in the best driver available on your platform.
 
 # Canvas
 
 ## List of Properties of the Canvas class
 
-`Mode`: get / set the mode of the video card to mode. It throws if the selected mode is not supported by the video card
-`DefaultGraphicMode`: default graphic mode this will change based on the underlying hardware
+`Mode`: get / set the mode of the video card to mode. It throws if the selected mode is not supported by the video card.\
+`DefaultGraphicMode`: default graphic mode this will change based on the underlying hardware\
 `AvailableModes`: list of the available modes supported this will change based on the underlying hardware
 
 ## List of Methods of the Canvas class
@@ -35,7 +49,7 @@ The `FullScreenCanvas` provides two methods to get a canvas instance for the scr
 
 
 Really simple right?
-# A working example (devkit only!)
+# A working example (DevKit only!)
 ```CSharp
 using System;
 using Sys = Cosmos.System;
@@ -64,7 +78,7 @@ namespace GraphicTest
                     243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 10, 66, 148, 255, 10, 66, 148, 255, 10, 66, 148, 255, 10, 66, 148,
                     255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255,
                     0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, 0, 255, 243, 255, }, ColorDepth.ColorDepth32);
-
+        
         protected override void BeforeRun()
         {
             // If all works correctly you should not really see this :-)
@@ -122,14 +136,14 @@ namespace GraphicTest
 ```
 # Limitations of the current implementation
 
-1. Only 32 bit color depth is actually supported, the API provides methods to set a resolution with 24, 16, 8 and 4 bit but the low level Bochs driver has not yet implemented them. 
-If you use SVGAIICanvas, you can use 24 bit Color depth and if you use VGACanvas there are 3 modes: 320x200x8, 640x480x4 and 720x480x4.
+1. Only 32-bit color depth is actually supported. The API provides methods to set a resolution with 24, 16, 8 and 4 bit but the low level Bochs driver has not yet implemented them. 
+If you use SVGAIICanvas, you can use 24 bit Color depth, and if you use VGACanvas there are 3 modes: 320x200x8, 640x480x4 and 720x480x4.
 
 2. In addition, some other nice things could be implemented:
-    - Plugging System.Drawing functions for easier manipulation of colors
+    - Plugging System.Drawing functions for easier manipulation of colors.
+    - Plugging of System.Drawing functions for easier implementation of image conversion.
 
-3. CGS interacts badly with the uncaught exceptions and Kernel.Stop method: the screen will freeze without displaying any error message whatsoever. You must use the Sys.Power.Shutdown() function to properly shut down your computer.
+3. CGS interacts badly with uncaught exceptions and the Kernel.Stop method: the screen will freeze without displaying any error message whatsoever. You must use the Sys.Power.Shutdown() function to properly shut down your computer.
 
 # Old examples 
-
-In the web there are a lot of tutorials explaining how to use graphics in Cosmos, but most of them are outdated. Just remember that the new Mouse class is Sys.MouseManager and Pen has been replaced with Color.
+On the internet, there have been a lot of tutorials explaining how to use graphics in Cosmos, but most of them are outdated. Just remember that the new Mouse class is Sys.MouseManager and Pen has been replaced with Color.

--- a/Docs/articles/Kernel/Levels.md
+++ b/Docs/articles/Kernel/Levels.md
@@ -208,3 +208,5 @@ references.
 1 Ethernet 
 2 TCP/IP
 3 Application
+
+*Last updated on 28 July 2023.*

--- a/Docs/articles/Kernel/Levels.md
+++ b/Docs/articles/Kernel/Levels.md
@@ -1,6 +1,6 @@
 # Levels
 
-**Warning** This article is for a older version of Cosmos and it doesn't work for current version.
+**Warning:** This article is for a older version of Cosmos, and as such, does not represent the current version included in the DevKit.
 
 The security model of Cosmos will evolve and mature as
 Cosmos does, however the base model is presented here.

--- a/Docs/articles/Kernel/ManifestResouceStream.md
+++ b/Docs/articles/Kernel/ManifestResouceStream.md
@@ -19,3 +19,5 @@ For example, if the project is called Kernel and the file is `Data\Text.txt`, th
 string fileContent = System.Text.Encoding.UTF8.GetString(file); //convert the byte array to string (assuming text data)
 Console.WriteLine(fileContent); //write it out
 ```
+
+*Last updated on 28 July 2023.*

--- a/Docs/articles/Kernel/ManifestResouceStream.md
+++ b/Docs/articles/Kernel/ManifestResouceStream.md
@@ -1,15 +1,21 @@
 # Manifest Resource Streams
-Manifest Resource Streams allow you to include data from the files as byte arrays in your code. An example of its use is in the [ZMachine Demo](https://github.com/CosmosOS/Cosmos/blob/5973a3fae95c989dc13505184aff9a15aae9f65f/Demos/ZMachine/ZKernel/Kernel.cs#L19) 
+Manifest Resource Streams allow you to include data from files as byte arrays in your code. An example of its use is in the [ZMachine Demo](https://github.com/CosmosOS/Cosmos/blob/5973a3fae95c989dc13505184aff9a15aae9f65f/Demos/ZMachine/ZKernel/Kernel.cs#L19).
 
 ## How to use
-1. Set for the the file you want to use `Build As: Embedded Resource` using the File Properties window in VS.
+1. Set for the file you want to use `Build As: Embedded Resource` using the File Properties window in VS.
 ![image](https://user-images.githubusercontent.com/8559822/132468001-256b92d1-0b29-4db3-9ef5-3383bfdef023.png)
-2. In the code reference the file using the following format (a static byte array with the attribute):
+2. In the code, reference the file using the following format (a static byte array with the attribute):
 ```
 [ManifestResourceStream(ResourceName = "{project_name}.{path}.{to}.{filename_with_extension}")] 
 static byte[] file;
 ```
 The field _must_ be static but the name of the field (file) can be changed. You will also need to add `using IL2CPU.API.Attribs;` to the code.
+
 For example, if the project is called Kernel and the file is `Data\Text.txt`, then `ResourceName = "Kernel.Data.Text.txt"`.
 
 3. To access the data simply read from the byte array defined. 
+
+```csharp
+string fileContent = System.Text.Encoding.UTF8.GetString(file); //convert the byte array to string (assuming text data)
+Console.WriteLine(fileContent); //write it out
+```

--- a/Docs/articles/Kernel/MemoryManagement.md
+++ b/Docs/articles/Kernel/MemoryManagement.md
@@ -65,3 +65,5 @@ When `RAT.MinFreePages` is set to a positive value and the number of free pages 
 ### Internals
 
 The garbage collector uses the tracing approach, which means that during collection a graph of all reachable objects is created and all non-discovered objects are freed. The garbage collector will only check objects on pages which have a type where the `GCManaged` bit is set. The graph is created by starting from "root" objects which are either stored in static variables or part of the current stack. Each of these objects is "marked" and all objects referenced by this object are recursivly also "marked" and "swept". This is done using the methods `void Heap.MarkAndSweepObject(void* aPtr)` for objects and `void Heap.SweepTypedObject(uint* obj, uint type)` for structures. For this to work each allocated object holds a 1bit flag if the object was discovered during the marking phase and a 7bit value counter for the number of static references it has. The number of static references an object has is updated using `void GCImplementation.IncRootCount(ushort* aPtr)` and similar methods, which are called from the Stsfld opcode.
+
+*Last updated on 22 October 2023.*

--- a/Docs/articles/Kernel/MemoryManagement.md
+++ b/Docs/articles/Kernel/MemoryManagement.md
@@ -12,9 +12,9 @@ This article provides an overview of how both Memory Allocation and the Garbage 
 
 #### Allocation
 
-Usually users should be allocating memory indirectly by using `new` or other standard methods provided by .Net to allocate new objects. In the cases, where you want to allocate a managed block of memory, which is not part of a certain .Net type, a `ManagedMemoryBlock` or `byte[]` should suffice. If this is not sufficient, one can use `uint GCImplementation.AllocNewObject(uint aSize)` to allocate a region of `aSize` bytes. The returned uint contains the memory address and can be converted to pointer if required. 
+Usually, users should be allocating memory indirectly by using `new` or other standard methods provided by .Net to allocate new objects. In the cases, where you want to allocate a managed block of memory, which is not part of a certain .NET type, a `ManagedMemoryBlock` or `byte[]` should suffice. If this is not sufficient, one can use `uint GCImplementation.AllocNewObject(uint aSize)` to allocate a region of `aSize` bytes. The returned uint contains the memory address and can be converted to pointer if required. 
 
-One can manually free an object using `Heap.Free(void* aPtr)` or `GCImplementation.Free(object aObj)`. It is recommended to not manually free .Net objects unless you know what you are doing since Cosmos does not always recognise when it is accessing already freed memory and this can lead to very weird bugs. 
+One can manually free an object using `Heap.Free(void* aPtr)` or `GCImplementation.Free(object aObj)`. It is recommended to not manually free .NET objects unless you know what you are doing, since Cosmos does not always recognise when it is accessing already freed memory. This can lead to very weird bugs. 
 
 #### Information
 
@@ -22,7 +22,7 @@ Cosmos provides a few methods to get information about the heap status:
 
  - `GCImplementation.GetAvailableRAM()` returns the size of the memory in MB available to the heap
  - `GCImplementation.GetUsedRAM()` provides a rough estimate of how many bytes are currently in use
- - `HeapSmall.GetAllocatedObjectCount()` returns the number of .Net objects currently allocated
+ - `HeapSmall.GetAllocatedObjectCount()` returns the number of .NET objects are currently allocated
  - `RAT.GetPageCount(byte aType)` returns how many pages of a certain type are allocated. The different type definitions are stored in `RAT.PageType`
 
 ### Internals

--- a/Docs/articles/Kernel/Network.md
+++ b/Docs/articles/Kernel/Network.md
@@ -200,3 +200,5 @@ using(var xClient = new DnsClient())
     Address destination = xClient.Receive(); //can set a timeout value
 }
 ```
+
+*Last updated on 24 March 2024.*

--- a/Docs/articles/Kernel/Network.md
+++ b/Docs/articles/Kernel/Network.md
@@ -1,18 +1,17 @@
 # Network
 
-In this article we will discuss about Networking on Cosmos, how to use the Network Stack, send and receive packets. For now, available protocols are **ARP**, **IPv4**, **TCP**, **UDP**, **ICMP**, **DHCP** and **DNS**. Note that Cosmos devkit must be installed for this article.
+In this article, we will discuss Networking on Cosmos, how to use the Network Stack, and send and receive packets. For now, available protocols are **ARP**, **IPv4**, **TCP**, **UDP**, **ICMP**, **DHCP** and **DNS**. Note that Cosmos DevKit must be installed for this article.
 
-All protocols here don't necessary support every feature described by their RFC and may have some bugs or architecture issues, if you find bugs or something abnormal please [submit an issue](https://github.com/CosmosOS/Cosmos/issues/new/choose) on our repository. 
+All protocols here don't necessarily support every feature described by their RFC and may have some bugs or architecture issues, if you find bugs or something abnormal please [submit an issue](https://github.com/CosmosOS/Cosmos/issues/new/choose) on our repository. 
 
 Each protocol has a Client class which can be used to receive and send data. If a Receive() method is blocking, the method will timeout after 5 seconds or use the value optionally set by parameter. Please note that all finished connections should be closed using Close().
 
-The Cosmos Network Stack mainly not uses classes and functions that are under .NET Core (except TCP). Everything described here will be under:
+The Cosmos Network Stack does not uses classes and functions that are under .NET Core (except TCP). Everything described here will be under:
 ```csharp
 using Cosmos.System.Network;
 ```
 
 Before anything, a Network Configuration must be set (local machine IPv4 address, subnet mask and gateway). It can be manually set with IPConfig.Enable or dynamically set through a DHCP server. For DHCP, Cosmos will ask to the DHCP server (usually default gateway) for an address in your local network.
-
 ### Manually set IPv4 Config
 ```csharp
 NetworkDevice nic = NetworkDevice.GetDeviceByName("eth0"); //get network device by name
@@ -32,7 +31,6 @@ using(var xClient = new DHCPClient())
 ```csharp
 Console.WriteLine(NetworkConfiguration.CurrentAddress.ToString());
 ```
-
 ## UDP
 Before playing with packets, we have to create a client and call Connect() to specify the remote machine address. After that the client will be able to send or listen for data.
 ```csharp
@@ -143,7 +141,7 @@ using(TcpClient client = new TcpClient())
 ```
 
 ## FTP
-Only server side is implemented in Cosmos. We recommand to use FileZilla as your FTP client.
+Only server-side FTP is implemented within Cosmos. We recommend to use FileZilla as your FTP client.
 
 **Your FTP client must enable active mode**. Since in Active Mode the server has to open TCP connections, **your computer firewall must be disabled** to accept incoming connection. An FTP connection is made of two TCP sockets. One for control connection (as a textual protocol) and one for data transmission. Data transmission sockets can be opened by the client (if it is in Passive Mode) or by the server (if in Active Mode). The Passive Mode is not supported yet due to current Cosmos TCP and multithreading limitation.
 
@@ -153,7 +151,7 @@ Install CosmosFtpServer package into your Cosmos kernel. For more information se
 
 ### FTP client configuration:
 
-Use Plain FTP with an Anonymous connection.
+Use Plain FTP with an anonymous connection:
 
 ![FTP client configuration](https://user-images.githubusercontent.com/18724279/121685499-4c71f380-cac0-11eb-8d08-6db1c0096e68.png)
 
@@ -193,7 +191,7 @@ DNS can be used to get an IP address from a Domain Name string. For now DNS can 
 ```csharp
 using(var xClient = new DnsClient())
 {
-    xClient.Connect(new Address(192, 168, 1, 254)); //DNS Server address
+    xClient.Connect(new Address(192, 168, 1, 254)); //DNS Server address. We recommend a Google or Cloudflare DNS, but you can use any you like!
 
     /** Send DNS ask for a single domain name **/
     xClient.SendAsk("github.com");

--- a/Docs/articles/Kernel/OnBoot.md
+++ b/Docs/articles/Kernel/OnBoot.md
@@ -1,5 +1,5 @@
 # OnBoot
-If you need to disable drivers because you are developing your own, or in some cases just don't need them, you may do so by adding the OnBoot method to your kernel. For now, you can disable 3 drivers and disable a part of a driver, an example would be
+If you need to disable drivers because you are developing your own, or in some cases just don't need them, you may do so by adding the OnBoot method to your kernel. For now, you can disable 3 drivers and disable a part of a driver, an example would be:
 
 ```csharp
 protected override void OnBoot() 
@@ -8,7 +8,7 @@ protected override void OnBoot()
 }
 ```
 
-In that example, we specify that the mousewheel is enabled, the PS2controller is loaded, network drivers are being loaded and the IDE controller is disabled.
+In that example, we specify that the Mousewheel is enabled, the PS2controller is loaded, network drivers are being loaded and the IDE controller is disabled.
 this is helpful if you intend on developing your own IDE controller, the order of the booleans is as stated above:
 `Mousewheel`
 `PS2Controller`

--- a/Docs/articles/Kernel/OnBoot.md
+++ b/Docs/articles/Kernel/OnBoot.md
@@ -14,3 +14,5 @@ this is helpful if you intend on developing your own IDE controller, the order o
 `PS2Controller`
 `Network Drivers`
 `IDE Controller`
+
+*Last updated on 24 March 2024.*

--- a/Docs/articles/Kernel/Plugs.md
+++ b/Docs/articles/Kernel/Plugs.md
@@ -2,12 +2,12 @@
 
 Plugs are used to fill "holes" in .NET libraries and replace them with different 
  code. Holes exist for example when a method in .NET library uses a Windows API 
- call. That API call will not be available on Cosmos. Emulating the win32 API would be highly inefficient. Instead, 
+ call. That API call will not be available on Cosmos. Emulating the Win32 API would be highly inefficient. Instead, 
  Cosmos replaces specific methods and property implementations that rely on 
- win32 API calls. Plugs can also be used to provide an alternate implementation 
+ Win32 API calls. Plugs can also be used to provide an alternate implementation 
  for a method, even if it does not rely on the Windows API.
  
- > **Important: All plugs must go in a seperate project, which is included in your original project using the `PlugReference` attribute in your kernels csproj.**
+ > **Important: All plugs must go in a seperate project, which is included in your original project using the `PlugReference` attribute in your Kernel's csproj.**
 
 ## Types of plugs
 
@@ -16,43 +16,36 @@ There are two types of plugs used and supported by Cosmos:
 *   Code Plug - A standard C# (or any .NET language) method is used to provide the alternate implementation.
 *   X#/Assembly Languge - In a few cases, it is difficult or impossible to write the code using C#/.Net since one needs exact control over the emitted assembly code. An assembly plug are designed for that case. Cosmos itself only uses this type of plug within the Cosmos.Core projects.
 
-## How do plugs work
+## How do plugs work?
 
-To explain  how plugs work, we first need to give an overview of how IL2CPU works. Roughly, IL2CPU compiles a kernel using the following steps: 
+To explain how plugs work, we first need to give an overview of how IL2CPU works. Roughly, IL2CPU compiles a kernel using the following steps: 
 1. IL2CPU determines a list of all methods and types which are used by the kernel.
 2. It then compiles each of these methods into assembly code. 
 This is usually done by getting the list of IL instructions which make up the method and translating each of them into some corresponding assembly.
 3. Together with a bit of boilerplate code, the emitted assembly for all the methods is compiled using yasm. 
 
-Plugs change what happens in step 2. A normal code plug means that rather taking the IL instructions from the original method, the IL instructions from the plug are used and then converted into assembly. An assembly plug directly states what asm should be emitted. 
+Plugs effect what occurs in Step 2; A normal code plug means that rather from taking the IL instructions from the original method, the IL instructions from the plug are used and then converted into assembly. An assembly plug directly states what asm should be emitted. 
 
 # Implementing a Plug
 
-While one always plugs individual methods, plugs are defined class wise. Therefore the first step to plugging any method is to define a new static class to contain all the pluggged methods for some certain type. This class must be decorated with the `Plug` attribute. The plug attribute either takes the type it is plugging(`Plug(Type target)`) or a string with the target name(`Plug(string targetName)`). Using the string target name is required when plugging internal or private classes. An example for a plugged class is for the Math class. https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.System2_Plugs/System/MathImpl.cs#L8-L9
+While one always plugs individual methods, plugs are defined class-wise. Therefore, the first step to plugging any method is to define a new static class to contain all the pluggged methods for some certain type. This class must be decorated with the `Plug` attribute. The plug attribute either takes the type it is plugging (`Plug(Type target)`), or a string with the target name(`Plug(string targetName)`). Using the string target name is required when plugging internal or private classes. An example for a plugged class is for the [Math class](https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.System2_Plugs/System/MathImpl.cs#L8-L9).
 
 ## Code Plug
 
-Once you have created such a class, you can add methods to the class. If these methods share the signature with a method in the original class they will be used to plug the original methods. For example in the above mentioned Math plug class, the following method plugs the original `double Math.Abs(double)` implementation.
-
-https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.System2_Plugs/System/MathImpl.cs#L52-L63
+Once you have created such a class, you can add methods to the class. If these methods share the signature with a method in the original class they will be used to plug the original methods. For example in the above mentioned Math plug class, the following method plugs the original `double Math.Abs(double)` implementation. [See here](https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.System2_Plugs/System/MathImpl.cs#L52-L63).
 
 Note, when plugging a non-static method, the first argument will be correspond to "this" (the instance for which the method is being called). 
 
-Sometimes it is impossible to define a method with exactly the same signature due to some of the arguments being from private or internal classes. In that case you can use the `PlugMethod` attribute. An example, is the following plug for `GC.AllocateNewArray` since `ALLOC_FLAGS` is a private enum. 
-https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.Core_Plugs/System/GCImpl.cs#L17-L29
+Sometimes it is impossible to define a method with exactly the same signature due to some of the arguments being from private or internal classes. In that case you can use the `PlugMethod` attribute. An example, is the following plug for `GC.AllocateNewArray` since `ALLOC_FLAGS` is a private enum. [See here](https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.Core_Plugs/System/GCImpl.cs#L17-L29).
 
 ## Assembly Plug
 
-Defining an assembly plug is slightly more complicated. The first step is the same and one needs to define a method with the same signature as the method one needs to plug. This acts as plug placeholder. The actual plug implemenation is a new class inheriting from `AssemblerMethod`. This class needs to override the `void AssembleNew(Assembler aAssembler, object aMethodInfo)` method. The `AssembleNew` method will be called when IL2CPU is executing and should emit the required asm. Examples of such classes can be found [here](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Plugs/MathImpl.cs) including the plug implementation for `double Math.Round(double)`,
+Defining an assembly plug is slightly more complicated. The first step is the same, and one needs to define a method with the same signature as the method one needs to plug. This acts as a plug placeholder. The actual plug implemenation is a new class inheriting from `AssemblerMethod`. This class needs to override the `void AssembleNew(Assembler aAssembler, object aMethodInfo)` method. The `AssembleNew` method will be called when IL2CPU is executing and should emit the required asm. Examples of such classes can be found [here](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Plugs/MathImpl.cs) including the plug implementation for `double Math.Round(double)` [here](https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.Core_Plugs/MathImpl.cs#L40-L49
+).
 
-https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.Core_Plugs/MathImpl.cs#L40-L49
+The final step is to link the plug implementation to the plug placeholder by adding a `PlugMethod(Type Assembler)` to the plug placeholder, where the `Assembler` value is the class you created with the implementation. An example is the plug placeholder for the above mentioned `double Math.Round(double)`, [here](https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.Core_Plugs/MathImpl.cs#L15-L19).
 
-The final step is to link the plug implementation to the plug placeholder by adding a `PlugMethod(Type Assembler)` to the plug placeholder, where the `Assembler` value is the class you created with the implementation. An example is the plug placeholder for the above mentioned `double Math.Round(double)`,
+## Using plugs to write Assembly in your Kernel
 
-https://github.com/CosmosOS/Cosmos/blob/8a8393353f1957890c5154650e29847fd22bf893/source/Cosmos.Core_Plugs/MathImpl.cs#L15-L19
-
-## Using plugs to write assembly in your kernel
-
-While plugs are usually used to overwrite existing methods in the .Net runtime, they can also be used to include assembly methods in your kernel. 
-This is for example done to implement the `void CPU.UpdateIDT(bool)` method in Cosmos. 
-To do this for your own classes and methods is not more difficult than plugging any other method. Simply set target of the plug class to your own class and write the assembly plug as usual. As a reference you can look at [Cosmos.Core/CPU.cs](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core/CPU.cs), [Cosmos.Core_Asm/CPUImpl.cs](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Asm/CPUImpl.cs) and [CPUUpdateIDTAsm.cs]( https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Asm/CPU/CPUUpdateIDTAsm.cs).
+While plugs are usually used to overwrite existing methods in the .NET runtime, they can also be used to include assembly methods in your kernel.
+This is for example, done to implement the `void CPU.UpdateIDT(bool)` method in Cosmos. To do this for your own classes and methods is not more difficult than plugging any other method. Simply set target of the plug class to your own class and write the assembly plug as usual. As a reference you can look at [Cosmos.Core/CPU.cs](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core/CPU.cs), [Cosmos.Core_Asm/CPUImpl.cs](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Asm/CPUImpl.cs) and [CPUUpdateIDTAsm.cs]( https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Asm/CPU/CPUUpdateIDTAsm.cs).

--- a/Docs/articles/Kernel/Plugs.md
+++ b/Docs/articles/Kernel/Plugs.md
@@ -49,3 +49,5 @@ The final step is to link the plug implementation to the plug placeholder by add
 
 While plugs are usually used to overwrite existing methods in the .NET runtime, they can also be used to include assembly methods in your kernel.
 This is for example, done to implement the `void CPU.UpdateIDT(bool)` method in Cosmos. To do this for your own classes and methods is not more difficult than plugging any other method. Simply set target of the plug class to your own class and write the assembly plug as usual. As a reference you can look at [Cosmos.Core/CPU.cs](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core/CPU.cs), [Cosmos.Core_Asm/CPUImpl.cs](https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Asm/CPUImpl.cs) and [CPUUpdateIDTAsm.cs]( https://github.com/CosmosOS/Cosmos/blob/master/source/Cosmos.Core_Asm/CPU/CPUUpdateIDTAsm.cs).
+
+*Last updated on 28 April 2023.*

--- a/Docs/articles/Kernel/Startup.md
+++ b/Docs/articles/Kernel/Startup.md
@@ -17,3 +17,5 @@ You can override the `Kernel.Start()` method in your Kernel to suppress the stan
 > You override it the same way you do with other methods. An extremely simple base override in your Kernel would be: `protected override void Start() {}`
 
 The default `Kernel.Start()` method is located in `Cosmos\source\Cosmos.System2\Kernel.cs`. You can copy it and make modifications with your Kernel override.
+
+*Last updated on 20 May 2023.*

--- a/Docs/articles/Kernel/Startup.md
+++ b/Docs/articles/Kernel/Startup.md
@@ -8,7 +8,7 @@ On startup, the first thing that happens is that the BIOS of your computer loads
 
 ### What does it do?
 `Kernel.Start()` does quite a bit of stuff. First, it checks if `System.String.Empty` is null. If it is null, then it will just throw an exception. If it isn't, it just continues. After that check, `Kernel.Start()` initializes the hardware bootstrap, then calls `OnBoot()`.
-> We have an article explaining what `OnBoot()` is.
+> The next article explains what `OnBoot()` is.
 
 Then, `Kernel.Start()` calls your `BeforeRun()` method, after it finishes, `Kernel.Start()` enables the hardware interrupts. Then it simply does a `while (!mStopped)` loop with your `Run()` method. After that, it calls an optional method called `AfterRun()`. By default, `AfterRun()` is just empty, so don't worry about nulls or something like that. Then it finishes. All of that is also try/catched too with the `A kernel exception has occurred` message.
 

--- a/Docs/articles/Kernel/VFS.md
+++ b/Docs/articles/Kernel/VFS.md
@@ -1,10 +1,11 @@
 # File System
 
-In this article we will discuss about using Cosmos VFS (virtual file system).
-Cosmos VFS and the VFS manager classes, let you manage your file system.
+In this article, we will discuss about using Cosmos VFS (virtual file system).\
+Cosmos VFS and the VFSManager classes, let you manage your file system.
 
-**Attention**: **Always** format your drive with Cosmos and **only** Cosmos if you plan to use it with Cosmos. Using any other tool such as Parted, FDisk (or any other tool) might lead to weird things when using that drive with Cosmos' VFS. Those tools are much more advanced and might format and read/write to the disk differently than Cosmos.
-**WARNING!**: Please do **not** try this on actual hardware! It may cause **IRREPARBLE DAMAGE** to your data. It is recommended to use a virtual machine like VMware, Hyper-V, just to name a few.
+**Attention**: **Always** format your drive with Cosmos and **only** Cosmos if you plan to use it with Cosmos. Using any other tool such as Parted, FDisk, or any other tool might lead to weird things when using that drive with Cosmos' VFS. Those tools are much more advanced and might format and read/write to the disk differently than Cosmos.
+
+**WARNING!**: Please do **not** try this on actual hardware! It may cause **IRREPARBLE DAMAGE** to your data. It is recommended to use a virtual machine like VMware or VirtualBox, just to name a few.
 
 First, we should create and initialize an instance of the VFS, this will initialize the partition and files-system lists, as well as register the new VFS.
 This is essential for using the VFS.
@@ -21,13 +22,14 @@ Next, we register our VFS at the VFS manager, this will initiate the VFS and mak
 Sys.FileSystem.VFS.VFSManager.RegisterVFS(fs);
 ```
 
-**Note**: From now on, we'll be using some plugged functions from ``System.IO``, so be sure to use that reference to your code. Alright, now, let's get started over some useful functions:
+**Note**: From now on, we'll be using some plugged functions from ``System.IO``, so be sure to use that reference to your code. Now, let's get started over some useful functions:
 
 ## Format disks
 
 **Note**: You don't have to format your drive if you're debugging your Cosmos project with VMWare. The build will automatically add an already formatted FAT32 VMDK file for your convenience.
 
-You can get all available disks using `VFSManager.GetDisks()`. The methods to get information about the disk or format it can be found under the [Disk](https://cosmosos.github.io/api/Cosmos.System.FileSystem.Disk.html) class. To format a disk use the [`FormatDisk(int index, string format, bool quick = true)`](https://cosmosos.github.io/api/Cosmos.System.FileSystem.Disk.html#Cosmos_System_FileSystem_Disk_FormatPartition_System_Int32_System_String_System_Boolean_)
+You can get all available disks using `VFSManager.GetDisks()`. The methods to get information about the disk or format it can be found under the [Disk](https://cosmosos.github.io/api/Cosmos.System.FileSystem.Disk.html) class. 
+To format a disk use the [`FormatDisk(int index, string format, bool quick = true)`](https://cosmosos.github.io/api/Cosmos.System.FileSystem.Disk.html#Cosmos_System_FileSystem_Disk_FormatPartition_System_Int32_System_String_System_Boolean_)
 method.
 
 
@@ -42,8 +44,8 @@ Console.WriteLine("Available Free Space: " + available_space);
 
 ![Free Space](https://raw.githubusercontent.com/CosmosOS/Cosmos/master/Docs/articles/Kernel/images/File%20System%20Free%20Space.PNG)
 
-You have probably noticed the "0:\" argument passed to this function, this is the id of the drive that we want to get available free space of.
-Cosmos using DOS drive naming system and this is why we use "0".
+You have probably noticed the "0:\" argument passed to this function, this is the ID of the drive that we want to get available free space of.
+Cosmos uses the DOS drive naming system, this is why we use "0".
 
 **Attention**: Typing "0:/" instead of "0:\\" might lead to errors, you've been warned.
 
@@ -59,7 +61,7 @@ var fs_type = fs.GetFileSystemType(@"0:\");
 Console.WriteLine("File System Type: " + fs_type);
 ```
 
-## Get files list
+## Get list of file
 
 We start by getting a list of files, using:
 
@@ -78,7 +80,7 @@ foreach (var file in files_list)
 
 ![Files List](https://raw.githubusercontent.com/CosmosOS/Cosmos/master/Docs/articles/Kernel/images/File%20System%20Files%20List.PNG)
 
-## Get directory listing (Files and directories)
+## Get directory listing (files and other directories)
 
 You can get files and directory listing by using this code: 
 
@@ -143,13 +145,13 @@ catch (Exception e)
 }
 ```
 
-## Create a new Directory
+## Create a new directory
 Here is a example of code of creating a new directory:
 
 ```C#
 try
 {
-    Directory.Create(@"0:\testing\");
+    Directory.Create(@"0:\testdirectory\");
 }
 catch (Exception e)
 {
@@ -165,7 +167,7 @@ You can also delete files or directories using this code:
 try
 {
     File.Delete(@"0:\testing.txt");
-    Directory.Delete(@"0:\testing\");
+    Directory.Delete(@"0:\testdirectory\");
 }
 catch (Exception e)
 {
@@ -192,7 +194,7 @@ catch (Exception e)
 
 ## Move a file
 
-Actually, File.Move() is not plugged in Cosmos, so you need to Copy the file and then delete the old file.
+File.Move() is not currently plugged in Cosmos, so you need to copy the file and then delete the old file.
 Here is an example Method:
 ```C#
 public static void MoveFile(string file, string newpath)
@@ -212,7 +214,7 @@ public static void MoveFile(string file, string newpath)
 
 ## Read all text from a specific file
 
-Now we will read a specific file from a given path.  
+Now, we will read a specific file from a given path.
 As usual, we'll do it in a try catch block.
 
 ```C#
@@ -230,7 +232,7 @@ catch (Exception e)
 
 # Read All bytes from a specific file
 
-As like the ReadAllText Method, ReadAllBytes should return all bytes the bytes from a file.
+As like the ReadAllText Method, ReadAllBytes should return all bytes the bytes from a file. You can use this to load files that include data and not just text.
 
 ```C#
 try

--- a/Docs/articles/Kernel/VFS.md
+++ b/Docs/articles/Kernel/VFS.md
@@ -1,6 +1,6 @@
 # File System
 
-In this article, we will discuss about using Cosmos VFS (virtual file system).\
+In this article, we will discuss about using Cosmos VFS (virtual file system).
 Cosmos VFS and the VFSManager classes, let you manage your file system.
 
 **Attention**: **Always** format your drive with Cosmos and **only** Cosmos if you plan to use it with Cosmos. Using any other tool such as Parted, FDisk, or any other tool might lead to weird things when using that drive with Cosmos' VFS. Those tools are much more advanced and might format and read/write to the disk differently than Cosmos.
@@ -244,3 +244,5 @@ catch (Exception e)
     Console.WriteLine(e.ToString());
 }
 ```
+
+*Last updated on 2 November 2023.*

--- a/Docs/articles/Reference/x86.md
+++ b/Docs/articles/Reference/x86.md
@@ -1,3 +1,5 @@
 # x86 Reference
 
-The reference can be found [here](http://ref.x86asm.net/)
+The reference can be found [here](http://ref.x86asm.net/).
+
+*Last updated on 20 June 2022.*

--- a/Docs/articles/Tests/TestRunner.md
+++ b/Docs/articles/Tests/TestRunner.md
@@ -27,3 +27,5 @@ To set the period before the TestRunner registers an error, change the line: `en
 
 ## Project Location
 The TestRunner Projects are located in ..\Tests\TestRunner
+
+*Last updated on 9 December 2022.*

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -1,20 +1,18 @@
 ﻿# Welcome to the Official Cosmos Documentation</h1>
   
-If you're new to Cosmos, welcome! Before you get stuck in the API documentation, we highly recommend you visit the website linked below.  
+If you're new to Cosmos, welcome! Before you get surf through the API documentation, we highly recommend you visit the website linked below.  
   
-The Articles section of this website includes some articles which have been written over years ago for websites such as www.codeproject.com and are mostly kept for archival purposes. These discuss elements such as the Cosmos Virtual File System. We prefer newcomers who want to develop their own operating systems to read the API documentation while we update these articles to comply with the current Cosmos project. 
+While majority of the content in this documentation is up-to-date, this website also includes some articles which have been written over years ago for websites such as www.codeproject.com. They are mostly kept for archival purposes. We prefer newcomers who want to develop their own operating systems to read the API documentation while we update these articles to comply with the current Cosmos project. 
+
+We **strongly** encourage newcomers to Cosmos to have a basic to intermediate proficiency in the [C# language](https://dotnet.microsoft.com/en-us/languages/csharp). Having this level of proficiency will significantly enable independent debugging and problem-solving, reducing the need for continuous assistance. There are many tutorials online for understanding classes, methods, and functions.
     
-For projects using the VFS directly, we recommend you use System.IO methods where possible. This is because these were written before much progress was made making .NET assemblies usable
+For projects using the Cosmos Virtual File System *(abbr. VFS)* directly, we recommend you use System.IO methods where possible. This is because these were written before much progress was made making .NET assemblies usable. 
   
-  
-For the up-to-date API documentation generated from the master branch, please visit the [Cosmos API Documentation](https://cosmosos.github.io/api/Cosmos.Build.Tasks.html)  
-  
-If you're looking for general information about Cosmos e.g. our goals and various links to chat with us or for help with using Cosmos that can't be answered with existing documentation, please visit the [Cosmos website](https://gocosmos.org)  
+For a comprehensive set of information about Cosmos, including our ambitions and other links to chat with us or to seek assistance with something not covered in the documentation, please visit the official [Cosmos website](https://www.gocosmos.org/).
 
 If you need a translation for this documentation, click [here](https://cosmosos-github-io.translate.goog/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp).
 
-
-You can find the latest and previous build statuses on [AppVeyor](https://ci.appveyor.com/project/CosmosOS/cosmos)  
+You can find the latest and previous build statuses on AppVeyor, [here](https://ci.appveyor.com/project/CosmosOS/cosmos).
 
 [![Build status](https://ci.appveyor.com/api/projects/status/kust7g5dlnykhkaf/branch/master?svg=true)](https://ci.appveyor.com/project/CosmosOS/cosmos/branch/master)  
 [![Join the chat at (https://discord.com/invite/kwtBwv6jhD](https://img.shields.io/discord/833970409337913344)](https://discord.com/invite/kwtBwv6jhD)


### PR DESCRIPTION
This should clean majority of the documentation on cosmosos.github.io to ensure clarity and for it to be up-to-date. Some articles (like the Levels.md) aren't touched because they are quite old.