### PR TITLE
Changed `PlugReference` to `PlugsReference`

### DIFF
--- a/Docs/articles/Kernel/Plugs.md
+++ b/Docs/articles/Kernel/Plugs.md
@@ -7,7 +7,7 @@ Plugs are used to fill "holes" in .NET libraries and replace them with different
  Win32 API calls. Plugs can also be used to provide an alternate implementation 
  for a method, even if it does not rely on the Windows API.
  
- > **Important: All plugs must go in a seperate project, which is included in your original project using the `PlugReference` attribute in your Kernel's csproj.**
+ > **Important: All plugs must go in a seperate project, which is included in your original project using the `PlugsReference` attribute in your Kernel's csproj.**
 
 ## Types of plugs
 


### PR DESCRIPTION
I generally try to avoid trivially small pull requests, but seeing as this typo cost me quite a bit of time I figured I'd try to save others from the same headache.