### PR TITLE
Update VisualStudioInstance.cs

### DIFF
--- a/source/Cosmos.Build.Builder/Models/VisualStudioInstance.cs
+++ b/source/Cosmos.Build.Builder/Models/VisualStudioInstance.cs
@@ -14,5 +14,7 @@ namespace Cosmos.Build.Builder.Models
         {
             SetupInstance = setupInstance;
         }
+
+        public override string ToString() => SetupInstance.GetInstallationName();
     }
 }


### PR DESCRIPTION
A quality of life update. Now when choosing a visual studio intance it will show like this:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/0cd0e038-ff19-4478-b753-bb101eb76e6e">
Instead of this:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/cd894b4f-0622-47b0-97d8-299ef0dd6bdb">
