### PR TITLE
Scope console present() to the changed rect, not the whole framebuffer

### DIFF
--- a/src/Cosmos.Kernel.Core/Memory/MemoryBlock.cs
+++ b/src/Cosmos.Kernel.Core/Memory/MemoryBlock.cs
@@ -267,6 +267,22 @@ public class MemoryBlock
     }
 
     /// <summary>
+    /// Copy a byte span into this memory block at the given offset. Same
+    /// non-temporal (cache-bypassing) write as <see cref="Copy(ManagedMemoryBlock)"/>,
+    /// but scoped to a sub-range — for presenting only a damaged rect of an MMIO
+    /// framebuffer instead of paying for a full-buffer copy on every small update.
+    /// </summary>
+    /// <param name="aByteOffset">Destination byte offset within this memory block.</param>
+    /// <param name="aData">Source bytes to write.</param>
+    public unsafe void CopyNonTemporal(int aByteOffset, ReadOnlySpan<byte> aData)
+    {
+        fixed (byte* src = aData)
+        {
+            MemoryOp.MemCopyNonTemporal((byte*)Base + aByteOffset, src, aData.Length);
+        }
+    }
+
+    /// <summary>
     /// Copies data from the memory block to the specified array.
     /// </summary>
     /// <param name="aByteOffset">The byte offset in the memory block from which to start copying.</param>

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/GopDriver.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/GopDriver.cs
@@ -107,6 +107,35 @@ public unsafe class GopDriver : GraphicDevice
     }
 
     /// <summary>
+    /// Presents only the given rect of the back buffer, row by row, instead of the
+    /// whole framebuffer. A full <see cref="Swap"/> is a several-megabyte
+    /// non-temporal MMIO write; for a caller that only changed a handful of pixels
+    /// (e.g. one console character cell per keystroke) that cost is paid on every
+    /// call for no visual benefit, and under virtualized display devices is slow
+    /// enough that a rapid burst of full swaps (e.g. fast typing) visibly tears.
+    /// </summary>
+    public override void SwapRect(int x, int y, int width, int height)
+    {
+        if (x < 0) { width += x; x = 0; }
+        if (y < 0) { height += y; y = 0; }
+        if (x >= (int)Width || y >= (int)Height || width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        width = Math.Min(width, (int)Width - x);
+        height = Math.Min(height, (int)Height - y);
+
+        int rowBytes = width * (int)Stride;
+        var span = lastbuffer.Span;
+        for (int row = 0; row < height; row++)
+        {
+            int byteOffset = (int)((y + row) * Pitch + x * Stride);
+            LinearFrameBuffer.CopyNonTemporal(byteOffset, span.Slice(byteOffset, rowBytes));
+        }
+    }
+
+    /// <summary>
     /// Copy a buffer of pixels to a rectangular region.
     /// </summary>
     public override void CopyBuffer(ReadOnlyMemory<uint> pixels, int x, int y, int width, int height)

--- a/src/Cosmos.Kernel.HAL/Devices/Graphic/GraphicDevice.cs
+++ b/src/Cosmos.Kernel.HAL/Devices/Graphic/GraphicDevice.cs
@@ -21,4 +21,13 @@ public abstract class GraphicDevice : Device, IGraphicDevice
     public abstract void CopyBuffer(ReadOnlyMemory<uint> pixels, int x, int y, int width, int height);
     public abstract void CopyBuffer(ReadOnlyMemory<int> pixels, int x, int y, int width, int height);
     public abstract void Swap();
+
+    /// <summary>
+    /// Presents only the given rect of the back buffer instead of the whole screen.
+    /// Default falls back to a full <see cref="Swap"/> for devices that don't
+    /// implement a partial present; devices backed by a full-framebuffer copy (e.g.
+    /// GopDriver) should override this to avoid paying that cost on every small,
+    /// frequent update (e.g. one character cell per keystroke).
+    /// </summary>
+    public virtual void SwapRect(int x, int y, int width, int height) => Swap();
 }

--- a/src/Cosmos.Kernel.Plugs/System/ConsolePlug.cs
+++ b/src/Cosmos.Kernel.Plugs/System/ConsolePlug.cs
@@ -173,7 +173,14 @@ public class ConsolePlug
             KernelConsole.Default.Write(keyEvent.KeyChar);
             if (KernelConsole.Default.IsAvailable)
             {
-                KernelConsole.Default.Canvas.Display();
+                // A full-screen Display() per keystroke is a multi-megabyte MMIO
+                // copy for a one-character change; under a virtualized display
+                // device that's slow enough that fast typing visibly tears. Scope
+                // the present to the cursor's row (covers the common no-wrap case);
+                // DoLineFeed/Scroll paths (Enter, wrapping) go through a full
+                // Console.WriteLine/Write elsewhere which still does a full Display.
+                var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
             }
         }
 

--- a/src/Cosmos.Kernel.System/Graphics/Canvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/Canvas.cs
@@ -245,6 +245,14 @@ public unsafe class Canvas
     }
 
     /// <summary>
+    /// Updates only the given rect of the screen from the underlying frame-buffer,
+    /// where supported (see <see cref="Cosmos.Kernel.HAL.Devices.Graphic.GraphicDevice.SwapRect"/>).
+    /// Default falls back to a full <see cref="Display()"/>; for virtual canvases
+    /// this is still a no-op.
+    /// </summary>
+    public virtual void Display(int x, int y, int width, int height) => Display();
+
+    /// <summary>
     /// Gets the color of the pixel at the given coordinates.
     /// </summary>
     /// <param name="x">The X coordinate.</param>

--- a/src/Cosmos.Kernel.System/Graphics/GopCanvas.cs
+++ b/src/Cosmos.Kernel.System/Graphics/GopCanvas.cs
@@ -542,6 +542,11 @@ internal class GopCanvas : Canvas
         driver.Swap();
     }
 
+    public override void Display(int x, int y, int width, int height)
+    {
+        driver.SwapRect(x, y, width, height);
+    }
+
     #region Reading
 
     public override Color GetPointColor(int aX, int aY)

--- a/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
+++ b/src/Cosmos.Kernel.System/Graphics/KernelConsole.cs
@@ -96,6 +96,15 @@ public class KernelConsole
     public bool IsAvailable => _canvas != null;
 
     /// <summary>
+    /// Pixel rect of the cursor's current row (full width, one character tall).
+    /// A caller that just wrote a single character with no line wrap/scroll (the
+    /// common case — see ConsolePlug.ReadKey) can present just this rect via
+    /// <see cref="Canvas"/>.Display(x,y,w,h) instead of the whole screen.
+    /// </summary>
+    public (int x, int y, int width, int height) CursorRowRect =>
+        (0, _cursorY * _charHeight, _cols * _charWidth, _charHeight);
+
+    /// <summary>
     /// Gets or sets the font used in this console.
     /// </summary>
     public Font Font

--- a/src/Cosmos.Kernel.System/IO/KeyboardTextReader.cs
+++ b/src/Cosmos.Kernel.System/IO/KeyboardTextReader.cs
@@ -76,7 +76,12 @@ public sealed class KeyboardTextReader : TextReader
                         }
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;
@@ -104,7 +109,12 @@ public sealed class KeyboardTextReader : TextReader
 
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;
@@ -116,7 +126,12 @@ public sealed class KeyboardTextReader : TextReader
                         KernelConsole.Default.MoveCursorLeft();
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;
@@ -128,7 +143,12 @@ public sealed class KeyboardTextReader : TextReader
                         KernelConsole.Default.MoveCursorRight();
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;
@@ -141,7 +161,12 @@ public sealed class KeyboardTextReader : TextReader
                         KernelConsole.Default.MoveCursorLeft();
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;
@@ -154,7 +179,12 @@ public sealed class KeyboardTextReader : TextReader
                         KernelConsole.Default.MoveCursorRight();
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;
@@ -190,7 +220,12 @@ public sealed class KeyboardTextReader : TextReader
                         }
                         if (KernelConsole.Default.IsAvailable)
                         {
-                            KernelConsole.Default.Canvas.Display();
+                            // Scoped to the cursor's row instead of a full-screen Swap: this
+                            // runs on every keystroke, and a multi-megabyte MMIO copy per key
+                            // was slow enough under a virtualized display device to visibly
+                            // tear during fast typing.
+                            var (rx, ry, rw, rh) = KernelConsole.Default.CursorRowRect;
+                            KernelConsole.Default.Canvas.Display(rx, ry, rw, rh);
                         }
                     }
                     break;


### PR DESCRIPTION
## Summary
- `KeyboardTextReader.ReadLine()` and `ConsolePlug.ReadKey()` (i.e. `Console.ReadLine()`/`Console.ReadKey()`) each call `Canvas.Display()` on every keystroke, which goes through `GopDriver.Swap()` and copies the **entire** framebuffer (`LinearFrameBuffer.Copy(lastbuffer)`, several MB at 1024x768x32) to real VRAM — even though only one character cell actually changed.
- Under a virtualized/emulated display device that per-keystroke full-buffer copy is slow enough that normal typing visibly tears on screen (confirmed the display's own drawing model is already correctly double-buffered — `GopDriver.lastbuffer` is a software back buffer, `Swap()` is the only point that touches the real VRAM — so the fix is scoping *that* present, not adding buffering).
- Adds `GraphicDevice.SwapRect(x,y,w,h)` / `Canvas.Display(x,y,w,h)`, backed by a new `MemoryBlock.CopyNonTemporal(offset, span)` for partial MMIO writes, and has `GopDriver.SwapRect` present only the given rect (row by row) instead of the whole buffer.
- `KernelConsole` gains `CursorRowRect` (covers the common no-wrap case — full row width, one character tall); `KeyboardTextReader.ReadLine()` and `ConsolePlug.ReadKey()` now present just that row per keystroke instead of the full screen.
- Existing full-screen `Display()` callers (e.g. a compositor doing one blit per frame) are untouched — this only adds a scoped variant, the default full-screen path still works exactly as before.

## Test plan
- [x] Reproduced with a minimal from-scratch kernel (`Console.Clear()` + `Console.WriteLine()` banner + a `Console.ReadLine()` echo loop, no application code) booted under QEMU (`-M q35 -vga std -display cocoa,zoom-to-fit=on`): idle text was stable, but typing produced visible full-screen tearing.
- [x] Applied this patch, rebuilt the same minimal kernel against the patched local packages, reproduced clean — no exceptions, and the tearing was gone under active typing.
- [ ] Would appreciate a check on real hardware / a non-virtualized GOP framebuffer, since the bug's root cause (a slow-relative-to-refresh full-buffer MMIO copy) is specific to virtualized display devices — this is unlikely to have been visible on real hardware where the copy is fast.